### PR TITLE
Use access_token for authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defender-relay-client",
-  "version": "0.2.5-rc.0",
+  "version": "0.2.5-rc.1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/__mocks__/amazon-cognito-identity-js.ts
+++ b/src/__mocks__/amazon-cognito-identity-js.ts
@@ -1,7 +1,7 @@
 const token = 'token';
 const mockAuthenticateUser = jest.fn((details, callbacks) => {
   callbacks.onSuccess({
-    getIdToken: () => ({
+    getAccessToken: () => ({
       getJwtToken: () => token,
     }),
   });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -23,7 +23,7 @@ export async function authenticate(authenticationData: UserPass): Promise<string
   return new Promise((resolve, reject) => {
     cognitoUser.authenticateUser(authenticationDetails, {
       onSuccess: function (result) {
-        const token = result.getIdToken().getJwtToken();
+        const token = result.getAccessToken().getJwtToken();
         resolve(token);
       },
       onFailure: function (err) {


### PR DESCRIPTION
- The backend now supports access_token authentication
- This replaces the use of ID Token in request