### PR TITLE
Add getRelayer to client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defender-relay-client",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/autotask-relayer.test.ts
+++ b/src/autotask-relayer.test.ts
@@ -68,6 +68,17 @@ describe('AutotaskRelayer', () => {
     });
   });
 
+  describe('getRelayer', () => {
+    test('passes correct arguments to the API', async () => {
+      await relayer.getRelayer();
+      expect(relayer.lambda.invoke).toBeCalledWith({
+        FunctionName: 'arn',
+        InvocationType: 'RequestResponse',
+        Payload: '{"action":"get-self"}',
+      });
+    });
+  });
+
   describe('sign', () => {
     test('passes correct arguments to the API', async () => {
       await relayer.sign({ message: 'test' });

--- a/src/autotask-relayer.ts
+++ b/src/autotask-relayer.ts
@@ -3,8 +3,10 @@ import { _Blob } from 'aws-sdk/clients/lambda';
 
 import {
   AutotaskRelayerParams,
+  GetSelfPayload,
   IRelayer,
   QueryPayload,
+  RelayerModel,
   RelayerTransaction,
   RelayerTransactionPayload,
   SendTxPayload,
@@ -51,6 +53,12 @@ export class AutotaskRelayer implements IRelayer {
     return this.execute({ action: 'send-tx', payload });
   }
 
+  public async getRelayer(): Promise<RelayerModel> {
+    return this.execute({
+      action: 'get-self' as const,
+    });
+  }
+
   public async query(id: string): Promise<RelayerTransaction> {
     return this.execute({
       action: 'get-tx' as const,
@@ -65,7 +73,7 @@ export class AutotaskRelayer implements IRelayer {
     });
   }
 
-  private async execute<T>(payload: SendTxPayload | QueryPayload | SignPayload): Promise<T> {
+  private async execute<T>(payload: SendTxPayload | QueryPayload | SignPayload | GetSelfPayload): Promise<T> {
     const result = await this.lambda
       .invoke({
         FunctionName: this.relayerARN,

--- a/src/relayer.test.ts
+++ b/src/relayer.test.ts
@@ -92,6 +92,14 @@ describe('ApiRelayer', () => {
     });
   });
 
+  describe('getRelayer', () => {
+    test('passes correct arguments to the API', async () => {
+      await relayer.getRelayer();
+      expect(relayer.api.get).toBeCalledWith('/relayer');
+      expect(initSpy).toBeCalled();
+    });
+  });
+
   describe('query', () => {
     test('passes correct arguments to the API', async () => {
       await relayer.query('42');

--- a/src/relayer.ts
+++ b/src/relayer.ts
@@ -27,6 +27,16 @@ export interface SignedMessagePayload {
   v: number;
 }
 
+export interface RelayerModel {
+  relayerId: string;
+  name: string;
+  address: string;
+  network: string;
+  paused: boolean;
+  createdAt: string;
+  pendingTxCost: string;
+}
+
 // from openzeppelin/defender/models/src/types/tx.res.ts
 export type RelayerTransaction = {
   transactionId: string;
@@ -60,6 +70,7 @@ function isApiCredentials(credentials: AutotaskRelayerParams | ApiRelayerParams)
 }
 
 export interface IRelayer {
+  getRelayer(): Promise<RelayerModel>;
   sendTransaction(payload: RelayerTransactionPayload): Promise<RelayerTransaction>;
   query(id: string): Promise<RelayerTransaction>;
   sign(payload: SignMessagePayload): Promise<SignedMessagePayload>;
@@ -78,6 +89,10 @@ export type QueryPayload = {
 export type SignPayload = {
   action: 'sign';
   payload: SignMessagePayload;
+};
+
+export type GetSelfPayload = {
+  action: 'get-self';
 };
 
 export class ApiRelayer implements IRelayer {
@@ -116,6 +131,12 @@ export class ApiRelayer implements IRelayer {
     }
   }
 
+  public async getRelayer(): Promise<RelayerModel> {
+    return this.wrapApiCall(async () => {
+      return (await this.api.get('/relayer')) as RelayerModel;
+    });
+  }
+
   public async sendTransaction(payload: RelayerTransactionPayload): Promise<RelayerTransaction> {
     return this.wrapApiCall(async () => {
       return (await this.api.post('/txs', payload)) as RelayerTransaction;
@@ -152,7 +173,11 @@ export class Relayer implements IRelayer {
     }
   }
 
-  sign(payload: SignMessagePayload): Promise<SignedMessagePayload> {
+  public getRelayer(): Promise<RelayerModel> {
+    return this.relayer.getRelayer();
+  }
+
+  public sign(payload: SignMessagePayload): Promise<SignedMessagePayload> {
     return this.relayer.sign(payload);
   }
 


### PR DESCRIPTION
## Summary
- This adds a `getRelayer()` function on the relayer client
- This is so that a client can get the address/properties of the relayer
- Incremented version to 0.3.0 per semantic versioning

This client requires this PR to merge for relayer-proxy to work:
https://github.com/OpenZeppelin/defender/pull/1006
