### PR TITLE
Do not load AutotaskRelayer by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-export { Relayer, RelayerTransaction, RelayerTransactionPayload } from './relayer';
-export { AutotaskRelayer } from './autotask';
-export { ApiRelayer } from './api';
+export * from './relayer';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 export const VERSION = require('../package.json').version;


### PR DESCRIPTION
The current setup was causing local scripts to fail since they were missing the aws-sdk dependency, required for running the autotask relayer. This change ensures that the autotask folder is lazy loaded.