### PR TITLE
Fix case insensitive address compare in ethers signer

### DIFF
--- a/packages/relay/src/ethers/signer.ts
+++ b/packages/relay/src/ethers/signer.ts
@@ -162,7 +162,7 @@ export class DefenderRelaySigner extends Signer {
     const tx = shallowCopy(transaction);
 
     tx.from = Promise.all([Promise.resolve(tx.from), this.getAddress()]).then((result) => {
-      if (result[0] != null && result[0] !== result[1]) {
+      if (!!result[0] && result[0].toLowerCase() !== result[1].toLowerCase()) {
         logger.throwArgumentError('from address mismatch', 'transaction', transaction);
       }
       return result[1];


### PR DESCRIPTION
[Reported in the forum](https://forum.openzeppelin.com/t/error-from-address-mismatch-gnosis-sdk-integration-in-autotask/14219/6?u=spalladino)