### PR TITLE
Update Forta Alert type to include chain Id

### DIFF
--- a/packages/autotask-utils/src/types.ts
+++ b/packages/autotask-utils/src/types.ts
@@ -237,6 +237,9 @@ export interface FortaAlert {
       id: string;
       name: string;
     };
+    block: {
+      chain_id: number;
+    };
   };
 }
 


### PR DESCRIPTION
A change was made to use the Chain Id property on the Forta Alert object to derive the originating network