### PR TITLE
Fix endpoints

### DIFF
--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -5,7 +5,41 @@ const { SentinelClient } = require('defender-sentinel-client');
 
 async function main() {
     const creds = { apiKey: process.env.ADMIN_API_KEY, apiSecret: process.env.ADMIN_API_SECRET };
+    console.log("Attempting to connect with:", creds);
     const client = new SentinelClient(creds);
+
+    // Succeeds
+    const notifs = await client.listNotificationChannels()
+    console.log("List notifications: ", notifs.length)
+
+    const blockWatchers = await client.listBlockwatchers()
+    console.log("List blockwatchers: ", blockWatchers.length)
+
+    const sentinels = await client.list()
+    console.log("List sentinels: ", sentinels.length)
+
+    const blockwatcherWithNetwork = await client.getBlockwatcherIdByNetwork('rinkeby')
+    console.log("List blockwatchers for rinkeby: ", blockwatcherWithNetwork.length)
+
+
+    // Fails
+    const createNotifRes = await client.createNotificationChannel('email', {
+        name: 'MyEmailNotification',
+        config: {
+            emails: ['john@example.com']
+        },
+        paused: false
+    })
+    console.log("Create a notification:", createNotifRes);
+
+    const pauseSentinel = await client.pause('ae0750d7-7d6f-427c-946e-f3352acf655e');
+    console.log("Pause a sentinel:", pauseSentinel);
+
+    const getSentinel = await client.get('ae0750d7-7d6f-427c-946e-f3352acf655e');
+    console.log("Get a sentinel:", getSentinel);
+
+
+
 
     let notification;
     // use an existing notification channel
@@ -30,7 +64,7 @@ async function main() {
         network: 'rinkeby',
         // optional
         confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
-        name: 'MyNewSentinel',
+        name: 'MyNewSentinel111',
         address: '0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2',
         abi: JSON.stringify(abi),
         // optional


### PR DESCRIPTION
**What's working:**

- List notifications [logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fstaging-api-api-notification-list/log-events/2021$252F11$252F23$252F$255B$2524LATEST$255D0f52cb70f78f421c977be541e80cc8ee)
- List blockwatchers [logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fstaging-api-api-block-watcher-list/log-events/2021$252F11$252F23$252F$255B$2524LATEST$255Ded1ebe55d9a74a0291139bf0cac9b4d0)
- List sentinels [logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fstaging-api-api-subscriber-list/log-events/2021$252F11$252F23$252F$255B$2524LATEST$255Db86866800fa746bd889678e47ef9b9ac)
- Create sentinels [logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fstaging-api-api-subscriber-create/log-events/2021$252F11$252F23$252F$255B$2524LATEST$255Dc4a6a7bed24f45f2a5f4e7a8800df53b)
- Get blockwatcher by ID (same logs as list but filter applied)

**What's not working (403 response):**

- Create a notification channel (no logs)
- Update a Sentinel with ID (no logs)
- Get Sentinel by ID (no logs)
- Delete Sentinel with ID (no logs)

No errors in the authoriser [logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fstaging-api-api-key-authorizer/log-events/2021$252F11$252F23$252F$255B$2524LATEST$255D019b459df37341df901ebdd2436cec2f)

The error:

```
{
  response: {
    status: 403,
    statusText: 'Forbidden',
    data: {
      message: "'eyJraWQiOiJpNEZROFRBK1wvd2tMZVl3WGd3Q0poRmZYdE1MaUgzSHRUUjdlTXI3M2Rzdz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxNjkzYTVjMC0yMGM5LTQyZDEtYWFiNi0wYjk5NzhhZDAwMDgiLCJldmVudF9pZCI6ImJlMWE4NjU2LTRlMTctNDc4YS1iMWE0LTg0MmJlMTE0M2QyNCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2Mzc2ODY0MzYsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0xX3B2alRTTmw5NCIsImV4cCI6MTYzNzY5MDAzNiwiaWF0IjoxNjM3Njg2NDM2LCJqdGkiOiI3NmFmYzMxMy1hYWUzLTRhYWYtYWUwNS1hZDI4MjZhY2U5Y2UiLCJjbGllbnRfaWQiOiIxb2d2am5wNTJkZDhwOG1rMmE3Y2RuajA0ZSIsInVzZXJuYW1lIjoiMkVyYmRpcDN5Tjc2aHRLb1huZ1A4R3hLYXdmSHU4elgifQ.ZPYg4WUg6gk--XMYiX1arq8unFyRe533uPW5A5xM1mBq_r_Gzn-AaQRzZrHpCPrrX32ivFz27Sb8d33efv1nR2JVPRSUXaluk3-x6PgTZ3DiqmXtxF755lwmbm41g6Th1IeG1HTmFjtdrNGexRCRi4qMHiaOPZcc7sdJEQLqTnRWczx_86ZmFAS2eVgBnT766ue0l4kCe-wk_UEuAIT7--A-6yBNekjXIJQBjHsLx9KlU6QaRao6e-7wyCIqxlfa49lGQmySHQoXsZNvhhORXEhUv-1e4l0v_2wM1v0yQImJdzCwDODUHGvAe_Ns-UkDA0bU6O5NpJKSUGUzHNzrzA' not a valid key=value pair (missing equal-sign) in Authorization header: 'Bearer eyJraWQiOiJpNEZROFRBK1wvd2tMZVl3WGd3Q0poRmZYdE1MaUgzSHRUUjdlTXI3M2Rzdz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxNjkzYTVjMC0yMGM5LTQyZDEtYWFiNi0wYjk5NzhhZDAwMDgiLCJldmVudF9pZCI6ImJlMWE4NjU2LTRlMTctNDc4YS1iMWE0LTg0MmJlMTE0M2QyNCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2Mzc2ODY0MzYsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0xX3B2alRTTmw5NCIsImV4cCI6MTYzNzY5MDAzNiwiaWF0IjoxNjM3Njg2NDM2LCJqdGkiOiI3NmFmYzMxMy1hYWUzLTRhYWYtYWUwNS1hZDI4MjZhY2U5Y2UiLCJjbGllbnRfaWQiOiIxb2d2am5wNTJkZDhwOG1rMmE3Y2RuajA0ZSIsInVzZXJuYW1lIjoiMkVyYmRpcDN5Tjc2aHRLb1huZ1A4R3hLYXdmSHU4elgifQ.ZPYg4WUg6gk--XMYiX1arq8unFyRe533uPW5A5xM1mBq_r_Gzn-AaQRzZrHpCPrrX32ivFz27Sb8d33efv1nR2JVPRSUXaluk3-x6PgTZ3DiqmXtxF755lwmbm41g6Th1IeG1HTmFjtdrNGexRCRi4qMHia
OPZcc7sdJEQLqTnRWczx_86ZmFAS2eVgBnT766ue0l4kCe-wk_UEuAIT7--A-6yBNekjXIJQBjHsLx9KlU6QaRao6e-7wyCIqxlfa49lGQmySHQoXsZNvhhORXEhUv-1e4l0v_2wM1v0yQImJdzCwDODUHGvAe_Ns-UkDA0bU6O5NpJKSUGUzHNzrzA'."
    }
  },
  message: 'Request failed with status code 403',
  request: {
    path: '/stg/subscribers/ae0750d7-7d6f-427c-946e-f3352acf655e',
    method: 'GET'
  }
}
```

To create notifications, it requires a `POST` to `/notifications/{type}`. 
Currently looks like the API gateway does not allow this. (not sure how to add this).
Similar issues with `PUT`, `GET` and `DELETE` to  `/subscribers/{subscriberid}`

<img width="214" alt="Screenshot 2021-11-23 at 17 39 29" src="https://user-images.githubusercontent.com/6783754/143076114-75f898f9-a964-4480-9dd3-0c79b9c460e7.png">
