### PR TITLE
Change response type for listing sentinels

### DIFF
--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -5,7 +5,7 @@ import {
   ExternalCreateSubscriberRequest as CreateSentinelRequest,
   NotificationReference,
 } from '../models/subscriber';
-import { DeletedSentinelResponse, CreateSentinelResponse } from '../models/response';
+import { DeletedSentinelResponse, CreateSentinelResponse, ListSentinelResponse } from '../models/response';
 import {
   NotificationSummary as NotificationResponse,
   NotificationType,
@@ -29,9 +29,9 @@ export class SentinelClient extends BaseApiClient {
     return process.env.DEFENDER_SENTINEL_API_URL || 'https://defender-api.openzeppelin.com/sentinel/';
   }
 
-  public async list(): Promise<CreateSentinelResponse[]> {
+  public async list(): Promise<ListSentinelResponse> {
     return this.apiCall(async (api) => {
-      return (await api.get('/subscribers')) as CreateSentinelResponse[];
+      return (await api.get('/subscribers')) as ListSentinelResponse;
     });
   }
 

--- a/packages/sentinel/src/models/response.ts
+++ b/packages/sentinel/src/models/response.ts
@@ -5,3 +5,10 @@ export interface DeletedSentinelResponse {
 }
 
 export type CreateSentinelResponse = CreateBlockSubscriberResponse;
+
+export type ListSentinelResponse = {
+  items: CreateSentinelResponse[];
+  notificationsQuotaUsage: number;
+  blockProcessedQuotaUsage: number;
+  fortaAlertsQuotaUsage: number;
+};


### PR DESCRIPTION
Changes the response type from `CreateSentinelResponse[]` to `ListSentinelResponse`

**CreateSentinelResponse[]**

```
[
    {
      notifyConfig: [Object],
      tenantId: '1c1385a9-1b86-4f9d-8468-28227802ac2b',
      createdAt: '2022-02-08T18:15:39.393Z',
      addressRules: [Array],
      blockWatcherId: 'rinkeby-1',
      subscriberId: '58b3d255-e357-4b0d-aa16-e86f745e63a7',
      paused: false,
      name: 'test',
      type: 'BLOCK',
      network: 'rinkeby'
    },
    ...
]
```

**ListSentinelResponse**

```
{
  items: [
    {
      notifyConfig: [Object],
      tenantId: '1c1385a9-1b86-4f9d-8468-28227802ac2b',
      createdAt: '2022-02-08T18:15:39.393Z',
      addressRules: [Array],
      blockWatcherId: 'rinkeby-1',
      subscriberId: '58b3d255-e357-4b0d-aa16-e86f745e63a7',
      paused: false,
      name: 'test',
      type: 'BLOCK',
      network: 'rinkeby'
    },
    ....
  ],
  notificationsQuotaUsage: 0,
  blockProcessedQuotaUsage: 0,
  fortaAlertsQuotaUsage: 0
}
```