### PR TITLE
Add/update modules in package.json

### DIFF
--- a/packages/sentinel/package.json
+++ b/packages/sentinel/package.json
@@ -21,10 +21,11 @@
   "author": "Nami Shah <nami@openzeppelin.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.2",
     "defender-base-client": "^1.16.0",
     "lodash": "^4.17.19",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "@ethersproject/abi": "^5.5.0"
   },
   "gitHead": "daddff62731a4b55075b57905d8c5b8c4eb3b80e"
 }


### PR DESCRIPTION
When following the npm installation instructions:
`npm install defender-sentinel-client`

Attempting to import `defender-sentinel-client` fails due to missing the `@ethersproject/abi` module.

If the monorepo is cloned and the development setup steps are followed, `yarn && yarn build`, the example code for creating a sentinel will succeed because the `@ethersproject/abi` module is present in `defender-client/node_modules/`.  If that copy is deleted, the example code fails due to missing the dependency.

Also, there appears to be a high severity vulnerability in `axios` versions <= 0.21.1:
https://github.com/advisories/GHSA-cph5-m8f7-6c5x