### PR TITLE
Add new routes to autotask-client

### DIFF
--- a/packages/autotask-client/src/api.ts
+++ b/packages/autotask-client/src/api.ts
@@ -1,5 +1,7 @@
 import { BaseApiClient } from 'defender-base-client';
 import { zipFolder, zipSources } from './zip';
+import { ListAutotaskResponse, CreateAutotaskResponse } from './models/response';
+import { CreateAutotaskRequest } from './models/config';
 
 type SourceFiles = {
   'index.js': string;
@@ -16,7 +18,20 @@ export class AutotaskClient extends BaseApiClient {
   }
 
   protected getApiUrl(): string {
-    return process.env.DEFENDER_AUTOTASK_API_URL || 'https://defender-api.openzeppelin.com/autotask/';
+    return process.env.DEFENDER_AUTOTASK_API_URL || 'https://defender-api.openzeppelin.com';
+  }
+
+  public async list(): Promise<ListAutotaskResponse> {
+    return this.apiCall(async (api) => {
+      return (await api.get('/autotasks/summary')) as ListAutotaskResponse;
+    });
+  }
+
+  public async get(autotaskId: string): Promise<CreateAutotaskResponse> {
+    return this.apiCall(async (api) => {
+      const response = (await api.get(`/autotasks/${autotaskId}`)) as CreateAutotaskResponse;
+      return response;
+    });
   }
 
   public async updateCodeFromZip(autotaskId: string, zippedCode: Buffer): Promise<void> {
@@ -36,7 +51,14 @@ export class AutotaskClient extends BaseApiClient {
 
   private async updateCode(autotaskId: string, encodedZippedCode: string): Promise<void> {
     return this.apiCall(async (api) => {
-      return await api.put(`/autotasks/${autotaskId}/code`, { encodedZippedCode });
+      return await api.put(`/autotask/autotasks/${autotaskId}/code`, { encodedZippedCode });
+    });
+  }
+
+  public async create(autotask: CreateAutotaskRequest): Promise<CreateAutotaskResponse> {
+    return this.apiCall(async (api) => {
+      const response = (await api.post('/autotasks', autotask)) as CreateAutotaskResponse;
+      return response;
     });
   }
 }

--- a/packages/autotask-client/src/models/config.ts
+++ b/packages/autotask-client/src/models/config.ts
@@ -1,0 +1,11 @@
+export interface AutotaskTriggerConfig {
+  cron?: string;
+  type: string;
+}
+
+export interface CreateAutotaskRequest {
+  name: string;
+  paused: boolean;
+  trigger: AutotaskTriggerConfig;
+  encodedZippedCode: string;
+}

--- a/packages/autotask-client/src/models/response.ts
+++ b/packages/autotask-client/src/models/response.ts
@@ -1,0 +1,25 @@
+export interface AutotaskScheduleTriggerResponse {
+  cron?: string;
+  frequencyMinutes?: number;
+  token: string;
+  type: string;
+}
+
+export interface AutotaskWebhookTriggerResponse {
+  token: string;
+  type: string;
+}
+
+export interface CreateAutotaskResponse {
+  autotaskId: string;
+  name: string;
+  paused: boolean;
+  trigger: AutotaskScheduleTriggerResponse | AutotaskWebhookTriggerResponse;
+  encodedZippedCode: string;
+};
+
+export type UpdateAutotaskConfigResponse = CreateAutotaskResponse;
+
+export interface ListAutotaskResponse {
+  items: CreateAutotaskResponse[];
+};


### PR DESCRIPTION
This PR adds more functionality (specifically create and read) to the autotask-client package, which is currently limited to only updating autotask code. I don't have insight into the exact specifics of the JSON data required for each request/response so the interfaces are 'best attempt.'