### PR TITLE
Fix defender-client sentinel API

### DIFF
--- a/packages/sentinel/src/models/response.ts
+++ b/packages/sentinel/src/models/response.ts
@@ -1,10 +1,13 @@
-import { CreateBlockSubscriberResponse } from './subscriber';
+import { 
+  CreateBlockSubscriberResponse,
+  CreateFortaSubscriberResponse
+} from './subscriber';
 
 export interface DeletedSentinelResponse {
   message: string;
 }
 
-export type CreateSentinelResponse = CreateBlockSubscriberResponse;
+export type CreateSentinelResponse = CreateBlockSubscriberResponse | CreateFortaSubscriberResponse;
 
 export type ListSentinelResponse = {
   items: CreateSentinelResponse[];

--- a/packages/sentinel/src/models/subscriber.ts
+++ b/packages/sentinel/src/models/subscriber.ts
@@ -1,4 +1,5 @@
 export interface ExternalCreateSubscriberRequest {
+  type: string;
   network: string;
   confirmLevel?: number;
   name: string;
@@ -13,6 +14,7 @@ export interface ExternalCreateSubscriberRequest {
   alertThreshold?: Threshold;
   alertTimeoutMs?: number;
   notificationChannels: string[];
+  fortaRule: FortaRule;
 }
 // Copied from openzeppelin/defender/models/src/types/subscribers.req.d.ts
 
@@ -43,6 +45,8 @@ export interface CreateBlockSubscriberRequest extends BaseCreateSubscriberReques
   network: Network;
   type: 'BLOCK';
 }
+
+export type CreateSentinelRequest = CreateFortaSubscriberRequest | CreateBlockSubscriberRequest;
 
 export interface CreateFortaSubscriberResponse extends BaseCreateSubscriberResponse, CreateFortaSubscriberRequest {
   fortaLastProcessedTime?: string;


### PR DESCRIPTION
This PR adds the ability to create Forta sentinels via the API.