### PR TITLE
update forta alert properties and add messageBody to notification

### DIFF
--- a/packages/autotask-utils/src/types.ts
+++ b/packages/autotask-utils/src/types.ts
@@ -241,25 +241,24 @@ export type BlockAlert = TFortaAlert & {
 interface TFortaAlert {
   addresses?: string[];
   severity: string;
-  alert_id: string;
-  scanner_count: number;
+  alertId: string;
+  scanNodeCount: number;
   name: string;
   description: string;
   hash: string;
   protocol: string;
-  type: string;
+  findingType: string;
   source: Source;
   alertType?: 'TX' | 'BLOCK';
 }
 
 interface Source {
-  tx_hash?: string;
+  transactionHash?: string;
   agent: {
     id: string;
-    name: string;
   };
   block: {
-    chain_id: number;
+    chainId: number;
     hash: string;
   };
 }

--- a/packages/sentinel/src/models/subscriber.ts
+++ b/packages/sentinel/src/models/subscriber.ts
@@ -67,35 +67,6 @@ export enum SubscriberType {
   FORTA = 'FORTA',
 }
 
-export const FortaAlertSeverity: { [key: string]: number } = {
-  UNKNOWN: 0,
-  INFO: 1,
-  LOW: 2,
-  MEDIUM: 3,
-  HIGH: 4,
-  CRITICAL: 5,
-};
-
-export interface FortaAlert {
-  addresses: string[];
-  severity: string;
-  alert_id: string;
-  scanner_count: number;
-  name: string;
-  description: string;
-  hash: string;
-  network: string;
-  protocol: string;
-  type: string;
-  source: {
-    tx_hash: string;
-    agent: {
-      id: string;
-      name: string;
-    };
-  };
-}
-
 export type Address = string;
 export interface AddressRule {
   conditions: ConditionSet[];
@@ -130,6 +101,7 @@ export interface Threshold {
 export interface Notifications {
   notifications: NotificationReference[];
   autotaskId?: string;
+  messageBody?: string;
   timeoutMs: number;
 }
 export interface NotificationReference {


### PR DESCRIPTION
Updates to the forta alert model in correspondence with the new API:
`alert_id` -> `alertId`
`scanner_count` -> `scanNodeCount`
`type` -> `findingType`
`tx_hash` -> `transactionHash`
`chain_Id` -> `chainId`
Agent `name` removed

The new `messageBody` property for custom notification formats has also been added