### PR TITLE
Add Forta sentinel support

### DIFF
--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -24,9 +24,42 @@ async function main() {
         })
     }
 
-    // populate the request parameters
+    // populate the request parameters for a Forta Sentinel
 
-    const requestParameters = {
+    const fortaRequestParameters = {
+        type: 'FORTA', // BLOCK or FORTA
+        name: 'MyNewFortaSentinel',
+        // optional
+        addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+        // optional
+        agentIDs: [],
+        fortaConditions: {
+            // optional
+            alertIDs: [],
+            minimumScannerCount: 0,
+            // optional
+            severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
+        },
+        // optional
+        paused: false,
+        // optional
+        autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+        // optional
+        autotaskTrigger: undefined,
+        // optional
+        alertThreshold: {
+            amount: 2,
+            windowSeconds: 3600,
+        },
+        // optional
+        alertTimeoutMs: 0,
+        notificationChannels: [notification.notificationId],
+    }
+
+    // populate the request parameters for a Block Sentinel
+
+    const blockRequestParameters = {
+        type: 'BLOCK', // BLOCK or FORTA
         network: 'rinkeby',
         // optional
         confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
@@ -57,7 +90,7 @@ async function main() {
     }
 
     // call create with the request parameters
-    const sentinelResponse = await client.create(requestParameters);
+    const sentinelResponse = await client.create(fortaRequestParameters);
 
     console.log(sentinelResponse);
 }

--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -24,38 +24,6 @@ async function main() {
         })
     }
 
-    // populate the request parameters for a Forta Sentinel
-
-    const fortaRequestParameters = {
-        type: 'FORTA', // BLOCK or FORTA
-        name: 'MyNewFortaSentinel',
-        // optional
-        addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-        // optional
-        agentIDs: [],
-        fortaConditions: {
-            // optional
-            alertIDs: [],
-            minimumScannerCount: 0,
-            // optional
-            severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
-        },
-        // optional
-        paused: false,
-        // optional
-        autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-        // optional
-        autotaskTrigger: undefined,
-        // optional
-        alertThreshold: {
-            amount: 2,
-            windowSeconds: 3600,
-        },
-        // optional
-        alertTimeoutMs: 0,
-        notificationChannels: [notification.notificationId],
-    }
-
     // populate the request parameters for a Block Sentinel
 
     const blockRequestParameters = {
@@ -89,8 +57,41 @@ async function main() {
         notificationChannels: [notification.notificationId],
     }
 
+    // populate the request parameters for a Forta Sentinel
+
+    const fortaRequestParameters = {
+        type: 'FORTA', // BLOCK or FORTA
+        name: 'MyNewFortaSentinel',
+        // optional
+        addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+        // optional
+        agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
+        fortaConditions: {
+            // optional
+            alertIDs: undefined, // string[]
+            minimumScannerCount: 0,
+            // optional
+            severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
+        },
+        // optional
+        paused: false,
+        // optional
+        autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+        // optional
+        autotaskTrigger: undefined,
+        // optional
+        alertThreshold: {
+            amount: 2,
+            windowSeconds: 3600,
+        },
+        // optional
+        alertTimeoutMs: 0,
+        notificationChannels: [notification.notificationId],
+    }
+
+
     // call create with the request parameters
-    const sentinelResponse = await client.create(fortaRequestParameters);
+    const sentinelResponse = await client.create(blockRequestParameters); // or fortaRequestParameters
 
     console.log(sentinelResponse);
 }

--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -69,7 +69,7 @@ async function main() {
         fortaConditions: {
             // optional
             alertIDs: undefined, // string[]
-            minimumScannerCount: 0,
+            minimumScannerCount: 1, // default is 1
             // optional
             severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
         },

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -172,7 +172,7 @@ const requestParameters = {
   fortaConditions: {
     // optional
     alertIDs: undefined, // string[]
-    minimumScannerCount: 0,
+    minimumScannerCount: 1, // default is 1
     // optional
     severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
   },

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -101,13 +101,16 @@ This returns a `NotificationResponse[]` object.
 
 ### Create a Sentinel
 
-To create a new sentinel, you need to provide the network, name, pause-state, conditions, alert threshold and notification configuration. This request is exported as type `CreateSentinelRequest`.
+There are two types of sentinels, `BLOCK` and `FORTA`. For more information on when to use which type, have a look at the documentation [https://docs.openzeppelin.com/defender/sentinel#when-to-use](here).
 
-An example is provided below. This sentinel will be named `MyNewSentinel` and will be monitoring the `renounceOwnership` function on the `0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2` contract on the Rinkeby network.
+To create a new sentinel, you need to provide the type, network, name, pause-state, conditions, alert threshold and notification configuration. This request is exported as type `CreateSentinelRequest`.
+
+An example for a `BLOCK` sentinel is provided below. This sentinel will be named `MyNewSentinel` and will be monitoring the `renounceOwnership` function on the `0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2` contract on the Rinkeby network.
 The alert threshold is set to 2 times within 1 hour, and the user will be notified via email.
 
 ```js
 const requestParameters = {
+  type: 'BLOCK',
   network: 'rinkeby',
   // optional
   confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
@@ -137,12 +140,6 @@ const requestParameters = {
 };
 ```
 
-Once you have these parameters all setup, you can create a sentinel by calling the `create` function on the client. This will return a `CreateSentinelResponse` object.
-
-```js
-await client.create(requestParameters);
-```
-
 If you wish to trigger the sentinel based on additional events, you could add another `EventCondition` or `FunctionCondition` object, for example:
 
 ```js
@@ -160,6 +157,46 @@ Possible variables: `value`, `gasPrice`, `gasLimit`, `gasUsed`, `to`, `from`, `n
 
 ```js
 txCondition: 'gasPrice > 0',
+```
+
+You can also construct a request for a `FORTA` sentinel as follows:
+
+```js
+const requestParameters = {
+  type: 'FORTA',
+  name: 'MyNewFortaSentinel',
+  // optional
+  addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+  // optional
+  agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
+  fortaConditions: {
+    // optional
+    alertIDs: undefined, // string[]
+    minimumScannerCount: 0,
+    // optional
+    severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
+  },
+  // optional
+  paused: false,
+  // optional
+  autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+  // optional
+  autotaskTrigger: undefined,
+  // optional
+  alertThreshold: {
+    amount: 2,
+    windowSeconds: 3600,
+  },
+  // optional
+  alertTimeoutMs: 0,
+  notificationChannels: [notification.notificationId],
+};
+```
+
+Once you have these parameters all setup, you can create a sentinel by calling the `create` function on the client. This will return a `CreateSentinelResponse` object.
+
+```js
+await client.create(requestParameters);
 ```
 
 Additionally, the sentinel could invoke an autotask to further evaluate. Documentation around this can be found here: https://docs.openzeppelin.com/defender/sentinel#autotask_conditions.

--- a/packages/sentinel/src/models/subscriber.ts
+++ b/packages/sentinel/src/models/subscriber.ts
@@ -1,19 +1,40 @@
-export interface ExternalCreateSubscriberRequest {
-  network: string;
-  confirmLevel?: number;
+export type ExternalCreateSubscriberRequest =
+  | ExternalCreateBlockSubscriberRequest
+  | ExternalCreateFortaSubscriberRequest;
+
+export interface ExternalBaseCreateSubscriberRequest {
   name: string;
+  paused?: boolean;
+  alertThreshold?: Threshold;
+  notifyConfig?: Notifications;
+  autotaskCondition?: string;
+  autotaskTrigger?: string;
+  alertTimeoutMs?: number;
+  notificationChannels: string[];
+  type: 'FORTA' | 'BLOCK';
+}
+export interface ExternalCreateBlockSubscriberRequest extends ExternalBaseCreateSubscriberRequest {
+  network: string;
+  confirmLevel?: number; // blockWatcherId
   address: string;
   abi?: string;
-  paused?: boolean;
   eventConditions?: EventCondition[];
   functionConditions?: FunctionCondition[];
   txCondition?: string;
-  autotaskCondition?: string;
-  autotaskTrigger?: string;
-  alertThreshold?: Threshold;
-  alertTimeoutMs?: number;
-  notificationChannels: string[];
+  type: 'BLOCK';
 }
+
+export interface ExternalCreateFortaSubscriberRequest extends ExternalBaseCreateSubscriberRequest {
+  network?: string;
+  fortaLastProcessedTime?: string;
+  addresses?: Address[];
+  agentIDs?: string[];
+  fortaConditions: FortaConditionSet;
+  type: 'FORTA';
+}
+
+export type CreateSubscriberRequest = CreateBlockSubscriberRequest | CreateFortaSubscriberRequest;
+
 // Copied from openzeppelin/defender/models/src/types/subscribers.req.d.ts
 
 import { Network } from './blockwatcher';
@@ -31,18 +52,26 @@ export interface BaseCreateSubscriberResponse extends BaseCreateSubscriberReques
   createdAt?: string;
 }
 
-export interface CreateFortaSubscriberRequest extends BaseCreateSubscriberRequest {
+export interface PartialCreateFortaSubscriberRequest {
   fortaRule: FortaRule;
-  type: 'FORTA';
   network?: Network;
+  type: 'FORTA';
 }
 
-export interface CreateBlockSubscriberRequest extends BaseCreateSubscriberRequest {
+export interface PartialCreateBlockSubscriberRequest {
   addressRules: AddressRule[];
   blockWatcherId: string;
   network: Network;
   type: 'BLOCK';
 }
+
+export interface CreateBlockSubscriberRequest
+  extends BaseCreateSubscriberRequest,
+    PartialCreateBlockSubscriberRequest {}
+
+export interface CreateFortaSubscriberRequest
+  extends BaseCreateSubscriberRequest,
+    PartialCreateFortaSubscriberRequest {}
 
 export interface CreateFortaSubscriberResponse extends BaseCreateSubscriberResponse, CreateFortaSubscriberRequest {
   fortaLastProcessedTime?: string;
@@ -141,6 +170,7 @@ export interface NotificationReference {
 // Copied from ui/src/components/sentinel/types.ts
 
 import { EventFragment, FunctionFragment } from '@ethersproject/abi';
+import { type } from 'os';
 
 export type Description = EventFragment | FunctionFragment;
 export type Condition = EventCondition | FunctionCondition | undefined;

--- a/packages/sentinel/src/models/subscriber.ts
+++ b/packages/sentinel/src/models/subscriber.ts
@@ -170,7 +170,6 @@ export interface NotificationReference {
 // Copied from ui/src/components/sentinel/types.ts
 
 import { EventFragment, FunctionFragment } from '@ethersproject/abi';
-import { type } from 'os';
 
 export type Description = EventFragment | FunctionFragment;
 export type Condition = EventCondition | FunctionCondition | undefined;


### PR DESCRIPTION
This PR adds Forta sentinels support to the defender-sentinel-client package.

TODO:

- [x] Update README
- [x] Update defender-docs (https://github.com/OpenZeppelin/defender-docs/pull/97)