### PR TITLE
Improve sentinel update request

### DIFF
--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -24,34 +24,34 @@ async function main() {
     });
   }
   const blockRequestParameters = {
-      type: 'BLOCK', // BLOCK or FORTA
-      network: 'rinkeby',
-      // optional
-      confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
-      name: 'MyNewSentinel',
-      addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-      abi: JSON.stringify(abi),
-      // optional
-      paused: false,
-      eventConditions: [
-          { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
-          { eventSignature: 'Transfer(address,address,uint256)' }
-      ],
-      functionConditions: [{ functionSignature: 'renounceOwnership()' }],
-      // optional
-      txCondition: 'gasPrice > 0',
-      // optional
-      autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-      // optional
-      autotaskTrigger: undefined,
-      // optional
-      alertThreshold: {
-          amount: 2,
-          windowSeconds: 3600,
-      },
-      // optional
-      alertTimeoutMs: 0,
-      notificationChannels: [notification.notificationId],
+    type: 'BLOCK', // BLOCK or FORTA
+    network: 'rinkeby',
+    // optional
+    confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
+    name: 'MyNewSentinel',
+    addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+    abi: JSON.stringify(abi),
+    // optional
+    paused: false,
+    eventConditions: [
+      { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
+      { eventSignature: 'Transfer(address,address,uint256)' }
+    ],
+    functionConditions: [{ functionSignature: 'renounceOwnership()' }],
+    // optional
+    txCondition: 'gasPrice > 0',
+    // optional
+    autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+    // optional
+    autotaskTrigger: undefined,
+    // optional
+    alertThreshold: {
+      amount: 2,
+      windowSeconds: 3600,
+    },
+    // optional
+    alertTimeoutMs: 0,
+    notificationChannels: [notification.notificationId],
   }
 
   const fortaRequestParameters = {
@@ -62,11 +62,11 @@ async function main() {
     // optional
     agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
     fortaConditions: {
-        // optional
-        alertIDs: undefined, // string[]
-        minimumScannerCount: 1, // default is 1
-        // optional
-        severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
+      // optional
+      alertIDs: undefined, // string[]
+      minimumScannerCount: 1, // default is 1
+      // optional
+      severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
     },
     // optional
     paused: false,
@@ -76,8 +76,8 @@ async function main() {
     autotaskTrigger: undefined,
     // optional
     alertThreshold: {
-        amount: 2,
-        windowSeconds: 3600,
+      amount: 2,
+      windowSeconds: 3600,
     },
     // optional
     alertTimeoutMs: 0,

--- a/examples/update-sentinel/index.js
+++ b/examples/update-sentinel/index.js
@@ -1,0 +1,17 @@
+require('dotenv').config();
+
+const { SentinelClient } = require('defender-sentinel-client');
+
+async function main() {
+  const creds = { apiKey: process.env.ADMIN_API_KEY, apiSecret: process.env.ADMIN_API_SECRET };
+  const client = new SentinelClient(creds);
+
+  const currentSentinel = await client.get("58b3d255-e357-4b0d-aa16-e86f745e63b9");
+  console.log(currentSentinel);
+  const updatedSentinel = await client.update(currentSentinel.subscriberId, { name: "Test 2" })
+  console.log(updatedSentinel)
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/examples/update-sentinel/package.json
+++ b/examples/update-sentinel/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "example-update-sentinel",
+  "version": "1.17.0",
+  "private": true,
+  "main": "index.js",
+  "author": "Nami Shah <nami@openzeppelin.com>",
+  "license": "MIT",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "defender-sentinel-client": "^1.17.0",
+    "dotenv": "^8.2.0"
+  }
+}

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -5,6 +5,7 @@ import {
   ExternalCreateBlockSubscriberRequest as CreateBlockSentinelRequest,
   ExternalCreateFortaSubscriberRequest as CreateFortaSentinelRequest,
   ExternalCreateSubscriberRequest as CreateSentinelRequest,
+  ExternalUpdateSubscriberRequest as UpdateSentinelRequest,
   NotificationReference,
   PartialCreateBlockSubscriberRequest,
   PartialCreateFortaSubscriberRequest,
@@ -52,13 +53,12 @@ export class SentinelClient extends BaseApiClient {
     });
   }
 
-  public async update(sentinelId: string, sentinel: CreateSentinelRequest): Promise<CreateSentinelResponse> {
+  public async update(sentinelId: string, sentinel: UpdateSentinelRequest): Promise<CreateSentinelResponse> {
     const currentSentinel = await this.get(sentinelId);
-    const newSentinel = await this.constructSentinelRequest(sentinel);
     return this.apiCall(async (api) => {
       return await api.put(`/subscribers/${sentinelId}`, {
         ...currentSentinel,
-        ...newSentinel,
+        ...sentinel,
       });
     });
   }

--- a/packages/sentinel/src/models/subscriber.ts
+++ b/packages/sentinel/src/models/subscriber.ts
@@ -2,6 +2,9 @@ export type ExternalCreateSubscriberRequest =
   | ExternalCreateBlockSubscriberRequest
   | ExternalCreateFortaSubscriberRequest;
 
+export type ExternalUpdateSubscriberRequest =
+  | ExternalUpdateBlockSubscriberRequest
+  | ExternalUpdateFortaSubscriberRequest;
 export interface ExternalBaseCreateSubscriberRequest {
   name: string;
   addresses?: string[];
@@ -33,6 +36,20 @@ export interface ExternalCreateFortaSubscriberRequest extends ExternalBaseCreate
   agentIDs?: string[];
   fortaConditions: FortaConditionSet;
   type: 'FORTA';
+}
+export interface ExternalUpdateBlockSubscriberRequest
+  extends Omit<ExternalCreateBlockSubscriberRequest, 'network' | 'addresses' | 'name' | 'notificationChannels'> {
+  network?: string;
+  addresses?: string[];
+  name?: string;
+  notificationChannels?: string[];
+}
+
+export interface ExternalUpdateFortaSubscriberRequest
+  extends Omit<ExternalCreateFortaSubscriberRequest, 'fortaConditions' | 'name' | 'notificationChannels'> {
+  fortaConditions?: FortaConditionSet;
+  name?: string;
+  notificationChannels?: string[];
 }
 
 export type CreateSubscriberRequest = CreateBlockSubscriberRequest | CreateFortaSubscriberRequest;


### PR DESCRIPTION
Improves the sentinel `update` endpoint by allowing to pass individual properties, rather than the entire `CreateSentinelRequest` object.