### PR TITLE
parse falsy values correctly for sentinel creation

### DIFF
--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -216,8 +216,8 @@ export class SentinelClient extends BaseApiClient {
       alertThreshold: sentinel.alertThreshold,
       notifyConfig: {
         notifications: await this.getNotifications(sentinel.notificationChannels),
-        autotaskId: sentinel.autotaskTrigger ?? undefined,
-        timeoutMs: sentinel.alertTimeoutMs ?? 0,
+        autotaskId: sentinel.autotaskTrigger ? sentinel.autotaskTrigger : undefined,
+        timeoutMs: sentinel.alertTimeoutMs ? sentinel.alertTimeoutMs : 0,
       },
       paused: sentinel.paused ? sentinel.paused : false,
     };


### PR DESCRIPTION
The `??` operator returns the right hand side of the operand if the left is `null` or `undefined`. An empty double quote `''` on the left hand side is deemed valid and returned. In the case of when creating a Sentinel where empty quotes are passed for an autotaskId, dynamo would receive empty quotes rather than `undefined`, since dynamo treats empty quotes as `null` the autotaskId is being set to an incorrect type. This means users could not update their sentinel through the UI due to type issues. 