### PR TITLE
Add failed status to Status type

### DIFF
--- a/packages/relay/src/relayer.ts
+++ b/packages/relay/src/relayer.ts
@@ -4,7 +4,7 @@ export type Address = string;
 export type BigUInt = string | number;
 export type Hex = string;
 export type Speed = 'safeLow' | 'average' | 'fast' | 'fastest';
-export type Status = 'pending' | 'sent' | 'submitted' | 'inmempool' | 'mined' | 'confirmed';
+export type Status = 'pending' | 'sent' | 'submitted' | 'inmempool' | 'mined' | 'confirmed' | 'failed';
 
 export type RelayerTransactionPayload = {
   to?: Address;


### PR DESCRIPTION
## Description

As per this [support request](https://forum.openzeppelin.com/t/why-isnt-failed-a-valid-status-returned-by-relayer-query-function/26584), I noted we don't have the `failed` status in the `Status` response type, although a user can request `failed` transactions using the `ListTransactionsRequest`.

Fixes https://github.com/OpenZeppelin/defender/issues/2517