### PR TITLE
Update defender-relay-client base url (#108)

### DIFF
--- a/packages/relay/src/api/index.ts
+++ b/packages/relay/src/api/index.ts
@@ -31,7 +31,7 @@ export class RelayClient extends BaseApiClient {
   }
 
   protected getApiUrl(): string {
-    return process.env.DEFENDER_RELAY_API_URL || 'https://defender-api.openzeppelin.com/';
+    return process.env.DEFENDER_RELAY_API_URL || 'https://defender-api.openzeppelin.com/relayer/';
   }
 
   public async get(relayerId: string): Promise<RelayerGetResponse> {


### PR DESCRIPTION
The base URL was incorrect on `defender-relay-client`, so it was non-functional in prod on latest release. Routing on back end has already been updated.

To test, pull in this branch, build the client package, and run the `create-relayer` example in production.

See: https://github.com/OpenZeppelin/defender-client/issues/108