### PR TITLE
Bump axios to 0.21.2

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -21,7 +21,7 @@
   "author": "Santiago Palladino <santiago@openzeppelin.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.2",
     "defender-base-client": "1.21.0",
     "lodash": "^4.17.19",
     "node-fetch": "^2.6.0"

--- a/packages/autotask-client/package.json
+++ b/packages/autotask-client/package.json
@@ -24,7 +24,7 @@
   "author": "Santiago Palladino <santiago@openzeppelin.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.2",
     "defender-base-client": "1.21.0",
     "dotenv": "^10.0.0",
     "glob": "^7.1.6",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "amazon-cognito-identity-js": "^4.3.3",
-    "axios": "^0.19.2",
+    "axios": "^0.21.2",
     "lodash": "^4.17.19",
     "node-fetch": "^2.6.0"
   },

--- a/packages/kvstore/package.json
+++ b/packages/kvstore/package.json
@@ -21,7 +21,7 @@
   "author": "Santiago Palladino <santiago@openzeppelin.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.2",
     "defender-base-client": "1.21.0",
     "fs-extra": "^10.0.0",
     "lodash": "^4.17.19",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "amazon-cognito-identity-js": "^4.3.3",
-    "axios": "^0.19.2",
+    "axios": "^0.21.2",
     "defender-base-client": "1.21.0",
     "lodash": "^4.17.19",
     "node-fetch": "^2.6.0"


### PR DESCRIPTION
There's a [high security vuln](https://github.com/advisories/GHSA-cph5-m8f7-6c5x) in axios <= 0.21.2.

Also this is blocking the same dependabot update on https://github.com/OpenZeppelin/defender/pull/2582