### PR TITLE
Add missing endpoints for notification channels

### DIFF
--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -23,71 +23,76 @@ async function main() {
       paused: false,
     });
   }
-  const blockRequestParameters = {
-    type: 'BLOCK', // BLOCK or FORTA
-    network: 'rinkeby',
-    // optional
-    confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
-    name: 'MyNewSentinel',
-    addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-    abi: JSON.stringify(abi),
-    // optional
-    paused: false,
-    eventConditions: [
-      { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
-      { eventSignature: 'Transfer(address,address,uint256)' }
-    ],
-    functionConditions: [{ functionSignature: 'renounceOwnership()' }],
-    // optional
-    txCondition: 'gasPrice > 0',
-    // optional
-    autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-    // optional
-    autotaskTrigger: undefined,
-    // optional
-    alertThreshold: {
-      amount: 2,
-      windowSeconds: 3600,
-    },
-    // optional
-    alertTimeoutMs: 0,
-    notificationChannels: [notification.notificationId],
-  }
 
-  const fortaRequestParameters = {
-    type: 'FORTA', // BLOCK or FORTA
-    name: 'MyNewFortaSentinel',
-    // optional
-    addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-    // optional
-    agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
-    fortaConditions: {
-      // optional
-      alertIDs: undefined, // string[]
-      minimumScannerCount: 1, // default is 1
-      // optional
-      severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
-    },
-    // optional
-    paused: false,
-    // optional
-    autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-    // optional
-    autotaskTrigger: undefined,
-    // optional
-    alertThreshold: {
-      amount: 2,
-      windowSeconds: 3600,
-    },
-    // optional
-    alertTimeoutMs: 0,
-    notificationChannels: [notification.notificationId],
-  }
+  console.log(notification);
 
-  // call create with the request parameters
-  const sentinelResponse = await client.create(blockRequestParameters); // or fortaRequestParameters
+  const deleted = await client.deleteNotificationChannel(notification);
+  console.log(deleted);
+  // const blockRequestParameters = {
+  //   type: 'BLOCK', // BLOCK or FORTA
+  //   network: 'rinkeby',
+  //   // optional
+  //   confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
+  //   name: 'MyNewSentinel',
+  //   addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+  //   abi: JSON.stringify(abi),
+  //   // optional
+  //   paused: false,
+  //   eventConditions: [
+  //     { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
+  //     { eventSignature: 'Transfer(address,address,uint256)' }
+  //   ],
+  //   functionConditions: [{ functionSignature: 'renounceOwnership()' }],
+  //   // optional
+  //   txCondition: 'gasPrice > 0',
+  //   // optional
+  //   autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+  //   // optional
+  //   autotaskTrigger: undefined,
+  //   // optional
+  //   alertThreshold: {
+  //     amount: 2,
+  //     windowSeconds: 3600,
+  //   },
+  //   // optional
+  //   alertTimeoutMs: 0,
+  //   notificationChannels: [notification.notificationId],
+  // }
 
-  console.log(sentinelResponse);
+  // const fortaRequestParameters = {
+  //   type: 'FORTA', // BLOCK or FORTA
+  //   name: 'MyNewFortaSentinel',
+  //   // optional
+  //   addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+  //   // optional
+  //   agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
+  //   fortaConditions: {
+  //     // optional
+  //     alertIDs: undefined, // string[]
+  //     minimumScannerCount: 1, // default is 1
+  //     // optional
+  //     severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
+  //   },
+  //   // optional
+  //   paused: false,
+  //   // optional
+  //   autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+  //   // optional
+  //   autotaskTrigger: undefined,
+  //   // optional
+  //   alertThreshold: {
+  //     amount: 2,
+  //     windowSeconds: 3600,
+  //   },
+  //   // optional
+  //   alertTimeoutMs: 0,
+  //   notificationChannels: [notification.notificationId],
+  // }
+
+  // // call create with the request parameters
+  // const sentinelResponse = await client.create(blockRequestParameters); // or fortaRequestParameters
+
+  // console.log(sentinelResponse);
 }
 
 if (require.main === module) {

--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -15,7 +15,8 @@ async function main() {
     notification = notificationChannels[0];
   } else {
     // OR create a new notification channel
-    notification = await client.createNotificationChannel('email', {
+    notification = await client.createNotificationChannel({
+      type: 'email',
       name: 'MyEmailNotification',
       config: {
         emails: ['john@example.com'],

--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -23,71 +23,78 @@ async function main() {
       paused: false,
     });
   }
-  const blockRequestParameters = {
-    type: 'BLOCK', // BLOCK or FORTA
-    network: 'rinkeby',
-    // optional
-    confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
-    name: 'MyNewSentinel',
-    addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-    abi: JSON.stringify(abi),
-    // optional
-    paused: false,
-    eventConditions: [
-      { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
-      { eventSignature: 'Transfer(address,address,uint256)' }
-    ],
-    functionConditions: [{ functionSignature: 'renounceOwnership()' }],
-    // optional
-    txCondition: 'gasPrice > 0',
-    // optional
-    autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-    // optional
-    autotaskTrigger: undefined,
-    // optional
-    alertThreshold: {
-      amount: 2,
-      windowSeconds: 3600,
-    },
-    // optional
-    alertTimeoutMs: 0,
-    notificationChannels: [notification.notificationId],
-  }
 
-  const fortaRequestParameters = {
-    type: 'FORTA', // BLOCK or FORTA
-    name: 'MyNewFortaSentinel',
-    // optional
-    addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-    // optional
-    agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
-    fortaConditions: {
-      // optional
-      alertIDs: undefined, // string[]
-      minimumScannerCount: 1, // default is 1
-      // optional
-      severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
-    },
-    // optional
-    paused: false,
-    // optional
-    autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-    // optional
-    autotaskTrigger: undefined,
-    // optional
-    alertThreshold: {
-      amount: 2,
-      windowSeconds: 3600,
-    },
-    // optional
-    alertTimeoutMs: 0,
-    notificationChannels: [notification.notificationId],
-  }
+  console.log(notification);
 
-  // call create with the request parameters
-  const sentinelResponse = await client.create(blockRequestParameters); // or fortaRequestParameters
+  const deleted = await client.deleteNotificationChannel(notification);
+  console.log(deleted);
 
-  console.log(sentinelResponse);
+  // // await client.dele
+  // const blockRequestParameters = {
+  //   type: 'BLOCK', // BLOCK or FORTA
+  //   network: 'rinkeby',
+  //   // optional
+  //   confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
+  //   name: 'MyNewSentinel',
+  //   addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+  //   abi: JSON.stringify(abi),
+  //   // optional
+  //   paused: false,
+  //   eventConditions: [
+  //     { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
+  //     { eventSignature: 'Transfer(address,address,uint256)' }
+  //   ],
+  //   functionConditions: [{ functionSignature: 'renounceOwnership()' }],
+  //   // optional
+  //   txCondition: 'gasPrice > 0',
+  //   // optional
+  //   autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+  //   // optional
+  //   autotaskTrigger: undefined,
+  //   // optional
+  //   alertThreshold: {
+  //     amount: 2,
+  //     windowSeconds: 3600,
+  //   },
+  //   // optional
+  //   alertTimeoutMs: 0,
+  //   notificationChannels: [notification.notificationId],
+  // }
+
+  // const fortaRequestParameters = {
+  //   type: 'FORTA', // BLOCK or FORTA
+  //   name: 'MyNewFortaSentinel',
+  //   // optional
+  //   addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+  //   // optional
+  //   agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
+  //   fortaConditions: {
+  //     // optional
+  //     alertIDs: undefined, // string[]
+  //     minimumScannerCount: 1, // default is 1
+  //     // optional
+  //     severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
+  //   },
+  //   // optional
+  //   paused: false,
+  //   // optional
+  //   autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+  //   // optional
+  //   autotaskTrigger: undefined,
+  //   // optional
+  //   alertThreshold: {
+  //     amount: 2,
+  //     windowSeconds: 3600,
+  //   },
+  //   // optional
+  //   alertTimeoutMs: 0,
+  //   notificationChannels: [notification.notificationId],
+  // }
+
+  // // call create with the request parameters
+  // const sentinelResponse = await client.create(blockRequestParameters); // or fortaRequestParameters
+
+  // console.log(sentinelResponse);
 }
 
 if (require.main === module) {

--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -23,78 +23,71 @@ async function main() {
       paused: false,
     });
   }
+  const blockRequestParameters = {
+    type: 'BLOCK', // BLOCK or FORTA
+    network: 'rinkeby',
+    // optional
+    confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
+    name: 'MyNewSentinel',
+    addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+    abi: JSON.stringify(abi),
+    // optional
+    paused: false,
+    eventConditions: [
+      { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
+      { eventSignature: 'Transfer(address,address,uint256)' }
+    ],
+    functionConditions: [{ functionSignature: 'renounceOwnership()' }],
+    // optional
+    txCondition: 'gasPrice > 0',
+    // optional
+    autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+    // optional
+    autotaskTrigger: undefined,
+    // optional
+    alertThreshold: {
+      amount: 2,
+      windowSeconds: 3600,
+    },
+    // optional
+    alertTimeoutMs: 0,
+    notificationChannels: [notification.notificationId],
+  }
 
-  console.log(notification);
+  const fortaRequestParameters = {
+    type: 'FORTA', // BLOCK or FORTA
+    name: 'MyNewFortaSentinel',
+    // optional
+    addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+    // optional
+    agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
+    fortaConditions: {
+      // optional
+      alertIDs: undefined, // string[]
+      minimumScannerCount: 1, // default is 1
+      // optional
+      severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
+    },
+    // optional
+    paused: false,
+    // optional
+    autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+    // optional
+    autotaskTrigger: undefined,
+    // optional
+    alertThreshold: {
+      amount: 2,
+      windowSeconds: 3600,
+    },
+    // optional
+    alertTimeoutMs: 0,
+    notificationChannels: [notification.notificationId],
+  }
 
-  const deleted = await client.deleteNotificationChannel(notification);
-  console.log(deleted);
+  // call create with the request parameters
+  const sentinelResponse = await client.create(blockRequestParameters); // or fortaRequestParameters
 
-  // // await client.dele
-  // const blockRequestParameters = {
-  //   type: 'BLOCK', // BLOCK or FORTA
-  //   network: 'rinkeby',
-  //   // optional
-  //   confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
-  //   name: 'MyNewSentinel',
-  //   addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-  //   abi: JSON.stringify(abi),
-  //   // optional
-  //   paused: false,
-  //   eventConditions: [
-  //     { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
-  //     { eventSignature: 'Transfer(address,address,uint256)' }
-  //   ],
-  //   functionConditions: [{ functionSignature: 'renounceOwnership()' }],
-  //   // optional
-  //   txCondition: 'gasPrice > 0',
-  //   // optional
-  //   autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-  //   // optional
-  //   autotaskTrigger: undefined,
-  //   // optional
-  //   alertThreshold: {
-  //     amount: 2,
-  //     windowSeconds: 3600,
-  //   },
-  //   // optional
-  //   alertTimeoutMs: 0,
-  //   notificationChannels: [notification.notificationId],
-  // }
-
-  // const fortaRequestParameters = {
-  //   type: 'FORTA', // BLOCK or FORTA
-  //   name: 'MyNewFortaSentinel',
-  //   // optional
-  //   addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-  //   // optional
-  //   agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
-  //   fortaConditions: {
-  //     // optional
-  //     alertIDs: undefined, // string[]
-  //     minimumScannerCount: 1, // default is 1
-  //     // optional
-  //     severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
-  //   },
-  //   // optional
-  //   paused: false,
-  //   // optional
-  //   autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-  //   // optional
-  //   autotaskTrigger: undefined,
-  //   // optional
-  //   alertThreshold: {
-  //     amount: 2,
-  //     windowSeconds: 3600,
-  //   },
-  //   // optional
-  //   alertTimeoutMs: 0,
-  //   notificationChannels: [notification.notificationId],
-  // }
-
-  // // call create with the request parameters
-  // const sentinelResponse = await client.create(blockRequestParameters); // or fortaRequestParameters
-
-  // console.log(sentinelResponse);
+  console.log(sentinelResponse);
 }
 
 if (require.main === module) {

--- a/examples/create-sentinel/index.js
+++ b/examples/create-sentinel/index.js
@@ -24,75 +24,71 @@ async function main() {
     });
   }
 
-  console.log(notification);
+  const blockRequestParameters = {
+    type: 'BLOCK', // BLOCK or FORTA
+    network: 'rinkeby',
+    // optional
+    confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
+    name: 'MyNewSentinel',
+    addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+    abi: JSON.stringify(abi),
+    // optional
+    paused: false,
+    eventConditions: [
+      { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
+      { eventSignature: 'Transfer(address,address,uint256)' }
+    ],
+    functionConditions: [{ functionSignature: 'renounceOwnership()' }],
+    // optional
+    txCondition: 'gasPrice > 0',
+    // optional
+    autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+    // optional
+    autotaskTrigger: undefined,
+    // optional
+    alertThreshold: {
+      amount: 2,
+      windowSeconds: 3600,
+    },
+    // optional
+    alertTimeoutMs: 0,
+    notificationChannels: [notification.notificationId],
+  }
 
-  const deleted = await client.deleteNotificationChannel(notification);
-  console.log(deleted);
-  // const blockRequestParameters = {
-  //   type: 'BLOCK', // BLOCK or FORTA
-  //   network: 'rinkeby',
-  //   // optional
-  //   confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
-  //   name: 'MyNewSentinel',
-  //   addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-  //   abi: JSON.stringify(abi),
-  //   // optional
-  //   paused: false,
-  //   eventConditions: [
-  //     { eventSignature: 'OwnershipTransferred(address,address)', expression: 'previousOwner=0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2' },
-  //     { eventSignature: 'Transfer(address,address,uint256)' }
-  //   ],
-  //   functionConditions: [{ functionSignature: 'renounceOwnership()' }],
-  //   // optional
-  //   txCondition: 'gasPrice > 0',
-  //   // optional
-  //   autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-  //   // optional
-  //   autotaskTrigger: undefined,
-  //   // optional
-  //   alertThreshold: {
-  //     amount: 2,
-  //     windowSeconds: 3600,
-  //   },
-  //   // optional
-  //   alertTimeoutMs: 0,
-  //   notificationChannels: [notification.notificationId],
-  // }
+  const fortaRequestParameters = {
+    type: 'FORTA', // BLOCK or FORTA
+    name: 'MyNewFortaSentinel',
+    // optional
+    addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
+    // optional
+    agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
+    fortaConditions: {
+      // optional
+      alertIDs: undefined, // string[]
+      minimumScannerCount: 1, // default is 1
+      // optional
+      severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
+    },
+    // optional
+    paused: false,
+    // optional
+    autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
+    // optional
+    autotaskTrigger: undefined,
+    // optional
+    alertThreshold: {
+      amount: 2,
+      windowSeconds: 3600,
+    },
+    // optional
+    alertTimeoutMs: 0,
+    notificationChannels: [notification.notificationId],
+  }
 
-  // const fortaRequestParameters = {
-  //   type: 'FORTA', // BLOCK or FORTA
-  //   name: 'MyNewFortaSentinel',
-  //   // optional
-  //   addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
-  //   // optional
-  //   agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
-  //   fortaConditions: {
-  //     // optional
-  //     alertIDs: undefined, // string[]
-  //     minimumScannerCount: 1, // default is 1
-  //     // optional
-  //     severity: 2, // (unknown=0, info=1, low=2, medium=3, high=4, critical=5)
-  //   },
-  //   // optional
-  //   paused: false,
-  //   // optional
-  //   autotaskCondition: '3dcfee82-f5bd-43e3-8480-0676e5c28964',
-  //   // optional
-  //   autotaskTrigger: undefined,
-  //   // optional
-  //   alertThreshold: {
-  //     amount: 2,
-  //     windowSeconds: 3600,
-  //   },
-  //   // optional
-  //   alertTimeoutMs: 0,
-  //   notificationChannels: [notification.notificationId],
-  // }
+  // call create with the request parameters
+  const sentinelResponse = await client.create(blockRequestParameters); // or fortaRequestParameters
 
-  // // call create with the request parameters
-  // const sentinelResponse = await client.create(blockRequestParameters); // or fortaRequestParameters
-
-  // console.log(sentinelResponse);
+  console.log(sentinelResponse);
 }
 
 if (require.main === module) {

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -90,6 +90,8 @@ const notification = await client.createNotificationChannel('datadog', {
 });
 ```
 
+### List notifications
+
 You can also list existing notification channels:
 
 ```js
@@ -99,7 +101,9 @@ const { notificationId, type } = notificationChannels[0];
 
 This returns a `NotificationResponse[]` object.
 
-You can also delete a notification channel. The notification object passed as a parameter should have at least the `type` and `notificationId` properties assigned.
+### Delete a notification
+
+You can also delete a notification channel. The notification object (`DeleteNotificationRequest`) passed as a parameter should have at least the `type` and `notificationId` properties assigned.
 
 ```js
 const notificationToDelete = { type: 'email', notificationId: 'e595ce88-f525-4d5d-b4b9-8e859310b6fb' };

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -99,7 +99,7 @@ const { notificationId, type } = notificationChannels[0];
 
 This returns a `NotificationResponse[]` object.
 
-Lastly, you can also delete a notification channel. The notification object passed as a parameter should have atleast the `type` and `notificationId` properties assigned.
+You can also delete a notification channel. The notification object passed as a parameter should have atleast the `type` and `notificationId` properties assigned.
 
 ```js
 const notificationToDelete = { type: 'email', notificationId: 'e595ce88-f525-4d5d-b4b9-8e859310b6fb' };

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -103,20 +103,22 @@ This returns a `NotificationResponse[]` object.
 
 ### Get a notification
 
-You can also retrieve a single notification channel. The function takes as parameters the `type` and `notificationId`.
+You can also retrieve a single notification channel. The function takes as parameter the `GetNotificationRequest` object, which must include the `type` and `notificationId` properties.
 
 ```js
-await client.getNotificationChannel('email', 'e595ce88-f525-4d5d-b4b9-8e859310b6fb');
+await client.getNotificationChannel({'email', 'e595ce88-f525-4d5d-b4b9-8e859310b6fb'});
 ```
 
 This returns a `NotificationResponse` object.
 
 ### Update a notification
 
-You can also update a single notification channel. The function takes as parameters the `type`, `notificationId` and a `NotificationRequest`.
+You can also update a single notification channel. The function takes as parameter the `UpdateNotificationRequest` object which must include the `type`, `notificationId` and `NotificationRequest` properties.
 
 ```js
-await client.updateNotificationChannel('email', 'e595ce88-f525-4d5d-b4b9-8e859310b6fb', {
+await client.updateNotificationChannel({
+  type: 'email',
+  notificationId: 'e595ce88-f525-4d5d-b4b9-8e859310b6fb',
   name: 'MyUpdatedEmailNotification',
   config: {
     emails: ['johndoe@example.com'],
@@ -129,10 +131,10 @@ This returns a `NotificationResponse` object.
 
 ### Delete a notification
 
-You can also delete a notification channel. The function takes as parameters the `type` and `notificationId`.
+You can also delete a notification channel. The function takes as a parameters the `DeleteNotificationRequest` object which must include the `type` and `notificationId` properties.
 
 ```js
-await client.deleteNotificationChannel('email', 'e595ce88-f525-4d5d-b4b9-8e859310b6fb');
+await client.deleteNotificationChannel({ type: 'email', notificationId: 'e595ce88-f525-4d5d-b4b9-8e859310b6fb' });
 ```
 
 ### Create a Sentinel

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -99,6 +99,20 @@ const { notificationId, type } = notificationChannels[0];
 
 This returns a `NotificationResponse[]` object.
 
+Lastly, you can also delete a notification channel. The notification object passed as a parameter should have atleast the `type` and `notificationId` properties assigned.
+
+```js
+const notificationToDelete = { type: 'email', notificationId: 'e595ce88-f525-4d5d-b4b9-8e859310b6fb' };
+await client.deleteNotificationChannel(notificationToDelete);
+```
+
+Alternatively, you could list all the notifications, and filter from the response accordingly.
+
+```js
+const notificationChannels = await client.listNotificationChannels();
+await client.deleteNotificationChannel(notificationChannels[0]);
+```
+
 ### Create a Sentinel
 
 There are two types of sentinels, `BLOCK` and `FORTA`. For more information on when to use which type, have a look at the documentation [https://docs.openzeppelin.com/defender/sentinel#when-to-use](here).

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -101,13 +101,38 @@ const { notificationId, type } = notificationChannels[0];
 
 This returns a `NotificationResponse[]` object.
 
-### Delete a notification
+### Get a notification
 
-You can also delete a notification channel. The notification object (`DeleteNotificationRequest`) passed as a parameter should have at least the `notificationId` properties assigned.
+You can also retrieve a single notification channel. The function takes as parameters the `type` and `notificationId`.
 
 ```js
-const notificationToDelete = { notificationId: 'e595ce88-f525-4d5d-b4b9-8e859310b6fb' };
-await client.deleteNotificationChannel(notificationToDelete);
+await client.getNotificationChannel('email', 'e595ce88-f525-4d5d-b4b9-8e859310b6fb');
+```
+
+This returns a `NotificationResponse` object.
+
+### Update a notification
+
+You can also update a single notification channel. The function takes as parameters the `type`, `notificationId` and a `NotificationRequest`.
+
+```js
+await client.updateNotificationChannel('email', 'e595ce88-f525-4d5d-b4b9-8e859310b6fb', {
+  name: 'MyUpdatedEmailNotification',
+  config: {
+    emails: ['johndoe@example.com'],
+  },
+  paused: false,
+});
+```
+
+This returns a `NotificationResponse` object.
+
+### Delete a notification
+
+You can also delete a notification channel. The function takes as parametera the `type` and `notificationId`.
+
+```js
+await client.deleteNotificationChannel('email', 'e595ce88-f525-4d5d-b4b9-8e859310b6fb');
 ```
 
 Alternatively, you could list all the notifications, and filter from the response accordingly.

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -103,10 +103,10 @@ This returns a `NotificationResponse[]` object.
 
 ### Delete a notification
 
-You can also delete a notification channel. The notification object (`DeleteNotificationRequest`) passed as a parameter should have at least the `type` and `notificationId` properties assigned.
+You can also delete a notification channel. The notification object (`DeleteNotificationRequest`) passed as a parameter should have at least the `notificationId` properties assigned.
 
 ```js
-const notificationToDelete = { type: 'email', notificationId: 'e595ce88-f525-4d5d-b4b9-8e859310b6fb' };
+const notificationToDelete = { notificationId: 'e595ce88-f525-4d5d-b4b9-8e859310b6fb' };
 await client.deleteNotificationChannel(notificationToDelete);
 ```
 

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -129,17 +129,10 @@ This returns a `NotificationResponse` object.
 
 ### Delete a notification
 
-You can also delete a notification channel. The function takes as parametera the `type` and `notificationId`.
+You can also delete a notification channel. The function takes as parameters the `type` and `notificationId`.
 
 ```js
 await client.deleteNotificationChannel('email', 'e595ce88-f525-4d5d-b4b9-8e859310b6fb');
-```
-
-Alternatively, you could list all the notifications, and filter from the response accordingly.
-
-```js
-const notificationChannels = await client.listNotificationChannels();
-await client.deleteNotificationChannel(notificationChannels[0]);
 ```
 
 ### Create a Sentinel

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -106,7 +106,7 @@ This returns a `NotificationResponse[]` object.
 You can also retrieve a single notification channel. The function takes as parameter the `GetNotificationRequest` object, which must include the `type` and `notificationId` properties.
 
 ```js
-await client.getNotificationChannel({'email', 'e595ce88-f525-4d5d-b4b9-8e859310b6fb'});
+await client.getNotificationChannel({ type: 'email', notificationId: 'e595ce88-f525-4d5d-b4b9-8e859310b6fb' });
 ```
 
 This returns a `NotificationResponse` object.

--- a/packages/sentinel/src/api/index.test.ts
+++ b/packages/sentinel/src/api/index.test.ts
@@ -2,7 +2,14 @@ import { AxiosInstance } from 'axios';
 import { SentinelClient } from '.';
 import { NotificationResponse } from '..';
 import { BlockWatcher } from '../models/blockwatcher';
-import { SaveNotificationRequest, SaveNotificationSlackRequest } from '../models/notification';
+import {
+  CreateNotificationRequest,
+  DeleteNotificationRequest,
+  GetNotificationRequest,
+  SaveNotificationRequest,
+  SaveNotificationSlackRequest,
+  UpdateNotificationRequest,
+} from '../models/notification';
 import { CreateSentinelResponse } from '../models/response';
 import { ExternalCreateBlockSubscriberRequest, ExternalCreateFortaSubscriberRequest } from '../models/subscriber';
 
@@ -346,14 +353,15 @@ describe('SentinelClient', () => {
   describe('createNotificationChannel', () => {
     it('passes correct arguments to the API', async () => {
       const type = 'slack';
-      const notification: SaveNotificationRequest = {
+      const notification: CreateNotificationRequest = {
+        type,
         name: 'some test',
         config: {
           url: 'test.slack.com',
         },
         paused: false,
       };
-      await sentinel.createNotificationChannel(type, notification);
+      await sentinel.createNotificationChannel(notification);
       expect(sentinel.api.post).toBeCalledWith(`/notifications/${type}`, notification);
       expect(initSpy).toBeCalled();
     });
@@ -371,16 +379,12 @@ describe('SentinelClient', () => {
   describe('deleteNotificationChannel', () => {
     it('passes correct arguments to the API', async () => {
       const type = 'slack';
-      const notification: NotificationResponse = {
-        name: 'some test',
-        config: {
-          url: 'test.slack.com',
-        },
-        paused: false,
-        notificationId: '1',
-        type: 'slack',
+      const notificationId = '1';
+      const notification: DeleteNotificationRequest = {
+        type,
+        notificationId,
       };
-      await sentinel.deleteNotificationChannel(type, notification.notificationId);
+      await sentinel.deleteNotificationChannel(notification);
       expect(sentinel.api.delete).toBeCalledWith(`/notifications/${type}/${notification.notificationId}`);
       expect(initSpy).toBeCalled();
     });
@@ -389,16 +393,12 @@ describe('SentinelClient', () => {
   describe('getNotificationChannel', () => {
     it('passes correct arguments to the API', async () => {
       const type = 'slack';
-      const notification: NotificationResponse = {
-        name: 'some test',
-        config: {
-          url: 'test.slack.com',
-        },
-        paused: false,
-        notificationId: '1',
-        type: 'slack',
+      const notificationId = '1';
+      const notification: GetNotificationRequest = {
+        type,
+        notificationId,
       };
-      await sentinel.getNotificationChannel(type, notification.notificationId);
+      await sentinel.getNotificationChannel(notification);
       expect(sentinel.api.get).toBeCalledWith(`/notifications/${type}/${notification.notificationId}`);
       expect(initSpy).toBeCalled();
     });
@@ -407,17 +407,19 @@ describe('SentinelClient', () => {
   describe('updateNotificationChannel', () => {
     it('passes correct arguments to the API', async () => {
       const type = 'slack';
-      const id = '1';
+      const notificationId = '1';
 
-      const notification: SaveNotificationSlackRequest = {
+      const notification: UpdateNotificationRequest = {
+        type,
+        notificationId,
         name: 'some test',
         config: {
           url: 'test.slack.com',
         },
         paused: false,
       };
-      await sentinel.updateNotificationChannel(type, id, notification);
-      expect(sentinel.api.put).toBeCalledWith(`/notifications/${type}/${id}`, notification);
+      await sentinel.updateNotificationChannel(notification);
+      expect(sentinel.api.put).toBeCalledWith(`/notifications/${type}/${notificationId}`, notification);
       expect(initSpy).toBeCalled();
     });
   });

--- a/packages/sentinel/src/api/index.test.ts
+++ b/packages/sentinel/src/api/index.test.ts
@@ -380,7 +380,25 @@ describe('SentinelClient', () => {
         notificationId: '1',
         type: 'slack',
       };
-      await sentinel.deleteNotificationChannel(notification);
+      await sentinel.deleteNotificationChannel(notification.notificationId);
+      expect(sentinel.api.delete).toBeCalledWith(`/notifications/${notification.notificationId}`);
+      expect(initSpy).toBeCalled();
+    });
+  });
+
+  describe('getNotificationChannel', () => {
+    it('passes correct arguments to the API', async () => {
+      const type = 'slack';
+      const notification: NotificationResponse = {
+        name: 'some test',
+        config: {
+          url: 'test.slack.com',
+        },
+        paused: false,
+        notificationId: '1',
+        type: 'slack',
+      };
+      await sentinel.getNotificationChannel(notification.notificationId);
       expect(sentinel.api.delete).toBeCalledWith(`/notifications/${notification.notificationId}`);
       expect(initSpy).toBeCalled();
     });

--- a/packages/sentinel/src/api/index.test.ts
+++ b/packages/sentinel/src/api/index.test.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from 'axios';
 import { SentinelClient } from '.';
 import { NotificationResponse } from '..';
 import { BlockWatcher } from '../models/blockwatcher';
-import { SaveNotificationRequest } from '../models/notification';
+import { SaveNotificationRequest, SaveNotificationSlackRequest } from '../models/notification';
 import { CreateSentinelResponse } from '../models/response';
 import { ExternalCreateBlockSubscriberRequest, ExternalCreateFortaSubscriberRequest } from '../models/subscriber';
 
@@ -380,8 +380,8 @@ describe('SentinelClient', () => {
         notificationId: '1',
         type: 'slack',
       };
-      await sentinel.deleteNotificationChannel(notification.notificationId);
-      expect(sentinel.api.delete).toBeCalledWith(`/notifications/${notification.notificationId}`);
+      await sentinel.deleteNotificationChannel(type, notification.notificationId);
+      expect(sentinel.api.delete).toBeCalledWith(`/notifications/${type}/${notification.notificationId}`);
       expect(initSpy).toBeCalled();
     });
   });
@@ -398,8 +398,26 @@ describe('SentinelClient', () => {
         notificationId: '1',
         type: 'slack',
       };
-      await sentinel.getNotificationChannel(notification.notificationId);
-      expect(sentinel.api.delete).toBeCalledWith(`/notifications/${notification.notificationId}`);
+      await sentinel.getNotificationChannel(type, notification.notificationId);
+      expect(sentinel.api.get).toBeCalledWith(`/notifications/${type}/${notification.notificationId}`);
+      expect(initSpy).toBeCalled();
+    });
+  });
+
+  describe('updateNotificationChannel', () => {
+    it('passes correct arguments to the API', async () => {
+      const type = 'slack';
+      const id = '1';
+
+      const notification: SaveNotificationSlackRequest = {
+        name: 'some test',
+        config: {
+          url: 'test.slack.com',
+        },
+        paused: false,
+      };
+      await sentinel.updateNotificationChannel(type, id, notification);
+      expect(sentinel.api.put).toBeCalledWith(`/notifications/${type}/${id}`, notification);
       expect(initSpy).toBeCalled();
     });
   });

--- a/packages/sentinel/src/api/index.test.ts
+++ b/packages/sentinel/src/api/index.test.ts
@@ -381,7 +381,7 @@ describe('SentinelClient', () => {
         type: 'slack',
       };
       await sentinel.deleteNotificationChannel(notification);
-      expect(sentinel.api.delete).toBeCalledWith(`/notifications/${notification.type}/${notification.notificationId}`);
+      expect(sentinel.api.delete).toBeCalledWith(`/notifications/${notification.notificationId}`);
       expect(initSpy).toBeCalled();
     });
   });

--- a/packages/sentinel/src/api/index.test.ts
+++ b/packages/sentinel/src/api/index.test.ts
@@ -368,6 +368,24 @@ describe('SentinelClient', () => {
     });
   });
 
+  describe('deleteNotificationChannel', () => {
+    it('passes correct arguments to the API', async () => {
+      const type = 'slack';
+      const notification: NotificationResponse = {
+        name: 'some test',
+        config: {
+          url: 'test.slack.com',
+        },
+        paused: false,
+        notificationId: '1',
+        type: 'slack',
+      };
+      await sentinel.deleteNotificationChannel(notification);
+      expect(sentinel.api.delete).toBeCalledWith(`/notifications/${notification.type}/${notification.notificationId}`);
+      expect(initSpy).toBeCalled();
+    });
+  });
+
   describe('listBlockwatchers', () => {
     it('calls API correctly', async () => {
       listBlockwatchersSpy.mockRestore();

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -109,7 +109,6 @@ export class SentinelClient extends BaseApiClient {
 
   public async deleteNotificationChannel(notification: NotificationResponse): Promise<string> {
     return this.apiCall(async (api) => {
-      console.log(api);
       return await api.delete(`/notifications/${notification.type}/${notification.notificationId}`);
     });
   }

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -17,7 +17,6 @@ import {
   NotificationSummary as NotificationResponse,
   NotificationType,
   SaveNotificationRequest as NotificationRequest,
-  DeleteNotificationRequest,
 } from '../models/notification';
 import { BlockWatcher, Network } from '../models/blockwatcher';
 
@@ -108,9 +107,25 @@ export class SentinelClient extends BaseApiClient {
     });
   }
 
-  public async deleteNotificationChannel(notification: DeleteNotificationRequest): Promise<string> {
+  public async deleteNotificationChannel(type: NotificationType, notificationId: string): Promise<string> {
     return this.apiCall(async (api) => {
-      return await api.delete(`/notifications/${notification.notificationId}`);
+      return await api.delete(`/notifications/${type}/${notificationId}`);
+    });
+  }
+
+  public async getNotificationChannel(type: NotificationType, notificationId: string): Promise<NotificationResponse> {
+    return this.apiCall(async (api) => {
+      return await api.get(`/notifications/${type}/${notificationId}`);
+    });
+  }
+
+  public async updateNotificationChannel(
+    type: NotificationType,
+    notificationId: string,
+    notification: NotificationRequest,
+  ): Promise<NotificationResponse> {
+    return this.apiCall(async (api) => {
+      return await api.put(`/notifications/${type}/${notificationId}`, notification);
     });
   }
 

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -110,7 +110,7 @@ export class SentinelClient extends BaseApiClient {
 
   public async deleteNotificationChannel(notification: DeleteNotificationRequest): Promise<string> {
     return this.apiCall(async (api) => {
-      return await api.delete(`/notifications/${notification.type}/${notification.notificationId}`);
+      return await api.delete(`/notifications/${notification.notificationId}`);
     });
   }
 

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -14,9 +14,11 @@ import {
 } from '../models/subscriber';
 import { DeletedSentinelResponse, CreateSentinelResponse, ListSentinelResponse } from '../models/response';
 import {
+  CreateNotificationRequest,
+  DeleteNotificationRequest,
+  GetNotificationRequest,
   NotificationSummary as NotificationResponse,
-  NotificationType,
-  SaveNotificationRequest as NotificationRequest,
+  UpdateNotificationRequest,
 } from '../models/notification';
 import { BlockWatcher, Network } from '../models/blockwatcher';
 
@@ -92,12 +94,9 @@ export class SentinelClient extends BaseApiClient {
     });
   }
 
-  public async createNotificationChannel(
-    type: NotificationType,
-    notification: NotificationRequest,
-  ): Promise<NotificationResponse> {
+  public async createNotificationChannel(notification: CreateNotificationRequest): Promise<NotificationResponse> {
     return this.apiCall(async (api) => {
-      return await api.post(`/notifications/${type}`, notification);
+      return await api.post(`/notifications/${notification.type}`, notification);
     });
   }
 
@@ -107,25 +106,21 @@ export class SentinelClient extends BaseApiClient {
     });
   }
 
-  public async deleteNotificationChannel(type: NotificationType, notificationId: string): Promise<string> {
+  public async deleteNotificationChannel(notification: DeleteNotificationRequest): Promise<string> {
     return this.apiCall(async (api) => {
-      return await api.delete(`/notifications/${type}/${notificationId}`);
+      return await api.delete(`/notifications/${notification.type}/${notification.notificationId}`);
     });
   }
 
-  public async getNotificationChannel(type: NotificationType, notificationId: string): Promise<NotificationResponse> {
+  public async getNotificationChannel(notification: GetNotificationRequest): Promise<NotificationResponse> {
     return this.apiCall(async (api) => {
-      return await api.get(`/notifications/${type}/${notificationId}`);
+      return await api.get(`/notifications/${notification.type}/${notification.notificationId}`);
     });
   }
 
-  public async updateNotificationChannel(
-    type: NotificationType,
-    notificationId: string,
-    notification: NotificationRequest,
-  ): Promise<NotificationResponse> {
+  public async updateNotificationChannel(notification: UpdateNotificationRequest): Promise<NotificationResponse> {
     return this.apiCall(async (api) => {
-      return await api.put(`/notifications/${type}/${notificationId}`, notification);
+      return await api.put(`/notifications/${notification.type}/${notification.notificationId}`, notification);
     });
   }
 

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -17,6 +17,7 @@ import {
   NotificationSummary as NotificationResponse,
   NotificationType,
   SaveNotificationRequest as NotificationRequest,
+  DeleteNotificationRequest,
 } from '../models/notification';
 import { BlockWatcher, Network } from '../models/blockwatcher';
 
@@ -107,7 +108,7 @@ export class SentinelClient extends BaseApiClient {
     });
   }
 
-  public async deleteNotificationChannel(notification: NotificationResponse): Promise<string> {
+  public async deleteNotificationChannel(notification: DeleteNotificationRequest): Promise<string> {
     return this.apiCall(async (api) => {
       return await api.delete(`/notifications/${notification.type}/${notification.notificationId}`);
     });

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -107,6 +107,13 @@ export class SentinelClient extends BaseApiClient {
     });
   }
 
+  public async deleteNotificationChannel(notification: NotificationResponse): Promise<string> {
+    return this.apiCall(async (api) => {
+      console.log(api);
+      return await api.delete(`/notifications/${notification.type}/${notification.notificationId}`);
+    });
+  }
+
   public async listBlockwatchers(): Promise<BlockWatcher[]> {
     return this.apiCall(async (api) => {
       return await api.get(`/blockwatchers`);

--- a/packages/sentinel/src/models/notification.ts
+++ b/packages/sentinel/src/models/notification.ts
@@ -59,10 +59,6 @@ export interface SaveNotificationDatadogRequest {
   config: DatadogConfig;
   paused: boolean;
 }
-export interface DeleteNotificationRequest {
-  notificationId: string;
-}
-
 export interface DatadogConfig {
   apiKey: string;
   metricPrefix: string;

--- a/packages/sentinel/src/models/notification.ts
+++ b/packages/sentinel/src/models/notification.ts
@@ -59,6 +59,11 @@ export interface SaveNotificationDatadogRequest {
   config: DatadogConfig;
   paused: boolean;
 }
+export interface DeleteNotificationRequest {
+  notificationId: string;
+  type: string;
+}
+
 export interface DatadogConfig {
   apiKey: string;
   metricPrefix: string;

--- a/packages/sentinel/src/models/notification.ts
+++ b/packages/sentinel/src/models/notification.ts
@@ -63,3 +63,13 @@ export interface DatadogConfig {
   apiKey: string;
   metricPrefix: string;
 }
+
+export interface NotificationRequest {
+  type: NotificationType;
+  notificationId: string;
+}
+
+export type DeleteNotificationRequest = NotificationRequest;
+export type UpdateNotificationRequest = NotificationRequest & SaveNotificationRequest;
+export type GetNotificationRequest = NotificationRequest;
+export type CreateNotificationRequest = Omit<NotificationRequest, 'notificationId'> & SaveNotificationRequest;

--- a/packages/sentinel/src/models/notification.ts
+++ b/packages/sentinel/src/models/notification.ts
@@ -61,7 +61,6 @@ export interface SaveNotificationDatadogRequest {
 }
 export interface DeleteNotificationRequest {
   notificationId: string;
-  type: string;
 }
 
 export interface DatadogConfig {


### PR DESCRIPTION
Note that this PR will break existing scripts that use the `createNotificationChannel` endpoint currently (parameters have changed).