### PR TITLE
Add new Forta Bot property

### DIFF
--- a/packages/autotask-utils/src/types.ts
+++ b/packages/autotask-utils/src/types.ts
@@ -138,6 +138,9 @@ export interface FortaSubscriberSummary {
   id: string;
   name: string;
   addresses: string[];
+  // Forta have changed the terminology for 'Agent' to 'Detection Bot'
+  // We will continue to refer to them as 'Agent' for now.
+  // agents should be a list of Bot IDs
   agents: string[];
   network?: string;
   chainId?: number;

--- a/packages/autotask-utils/src/types.ts
+++ b/packages/autotask-utils/src/types.ts
@@ -258,7 +258,11 @@ interface TFortaAlert {
 
 interface Source {
   transactionHash?: string;
+  // deprecated, keeping for backwards compatibility
   agent: {
+    id: string;
+  };
+  bot: {
     id: string;
   };
   block: {

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -168,6 +168,9 @@ const requestParameters = {
   // optional
   addresses: ['0x0f06aB75c7DD497981b75CD82F6566e3a5CAd8f2'],
   // optional
+  // NOTE: Forta have changed the terminology for 'Agent' to 'Detection Bot'.
+  // We will continue to refer to them as 'Agents' for now.
+  // agentIDs should be a list of your Bot IDs
   agentIDs: ['0x8fe07f1a4d33b30be2387293f052c273660c829e9a6965cf7e8d485bcb871083'],
   fortaConditions: {
     // optional

--- a/packages/sentinel/src/models/subscriber.ts
+++ b/packages/sentinel/src/models/subscriber.ts
@@ -33,6 +33,9 @@ export interface ExternalCreateFortaSubscriberRequest extends ExternalBaseCreate
   network?: Network;
   fortaLastProcessedTime?: string;
   addresses?: Address[];
+  // Forta have changed the terminology for 'Agent' to 'Detection Bot'
+  // We will continue to refer to them as 'Agent' for now.
+  // agentIDs should be a list of Bot IDs
   agentIDs?: string[];
   fortaConditions: FortaConditionSet;
   type: 'FORTA';
@@ -100,6 +103,9 @@ export interface CreateBlockSubscriberResponse extends BaseCreateSubscriberRespo
 
 export interface FortaRule {
   addresses?: Address[];
+  // Forta have changed the terminology for 'Agent' to 'Detection Bot'
+  // We will continue to refer to them as 'Agent' for now.
+  // agentIDs should be a list of Bot IDs
   agentIDs?: string[];
   conditions: FortaConditionSet;
   autotaskCondition?: AutotaskCondition;


### PR DESCRIPTION
[Forta have changed](https://github.com/forta-network/forta-api/issues/8) the name of their detection scripts from `agent` to `bot`. This PR adds the new `bot` property while keeping the old `agent` property to maintain backwards compatibility.