### PR TITLE
Add natSpec (as a string) to Contract interface

### DIFF
--- a/packages/admin/src/models/contract.ts
+++ b/packages/admin/src/models/contract.ts
@@ -7,4 +7,5 @@ export interface Contract {
   address: Address;
   name: string;
   abi?: string;
+  natSpec?: string;
 }


### PR DESCRIPTION
Add natSpec (as a string) to Contract interface

Warning: this pull request has a dependency on the merge of another request made to Defender related to the NatSpec feature development