### PR TITLE
Add Autotask CLI note

### DIFF
--- a/packages/autotask-client/README.md
+++ b/packages/autotask-client/README.md
@@ -44,7 +44,9 @@ $ defender-autotask execute-run $AUTOTASK_ID
 $ defender-autotask tail-runs $AUTOTASK_ID
 ```
 
-Note that the `defender-autotask` CLI will automatically load environment variables from a local `.env` file if found.
+Beware that the `defender-autotask` CLI will automatically load environment variables from a local `.env` file if found.
+
+**Note**: In order to get the CLI to work, it should've been installed globally, otherwise, you can prefix with `npx` if you're using it directly on bash. This is not necessary when running from your `package.json` defined scripts.
 
 ### Script usage
 


### PR DESCRIPTION
## Description

Someone at [the forum](https://forum.openzeppelin.com/t/defender-autotask-client-execution-command-not-found/29277/4) posted a question with a really valid concern.

Although this is a common behavior for every npm package that we can assume our users know, not everybody will. So I think it doesn't hurt to add the note on the usage example