### PR TITLE
fix: correct typing relayer client

### DIFF
--- a/packages/relay/src/relayer.ts
+++ b/packages/relay/src/relayer.ts
@@ -50,7 +50,7 @@ export interface RelayerGetResponse {
 export interface RelayerModel extends RelayerGetResponse {}
 
 export interface RelayerListResponse {
-  items: Relayer[];
+  items: RelayerGetResponse[];
   txsQuotaUsage: number;
 }
 


### PR DESCRIPTION
Hey OZ team!

We've recently started working closely with OZ Defender at Mean Finance. In particular, we've tried to automate all our entities (sentinels, autotasks, etc) management through the different clients. NChamo explains it better [here](https://forum.openzeppelin.com/t/what-are-your-needs-on-defender-user-permissions/29244/5?u=nchamo).

Anyways, we realized that the `RelayerClient.list` was returning the wrong type. We casted it to the correct type in our code, but we thought it made sense to fix it for everyone else.

`list` is basically just an API call, but it was returning a class. We think this fixes it, but let us know if we made a mistake or something.

Anyways, keep up the amazing work!