### PR TITLE
Add support for updating ABI with upgrade 

### DIFF
--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -12,7 +12,7 @@ type UpgradeParams = {
   via?: Address;
   viaType?: 'EOA' | 'Gnosis Safe' | 'Gnosis Multisig';
   newImplementation: string;
-  newImplementationAbi: string;
+  newImplementationAbi?: string;
 };
 
 type PauseParams = {

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -12,6 +12,7 @@ type UpgradeParams = {
   via?: Address;
   viaType?: 'EOA' | 'Gnosis Safe' | 'Gnosis Multisig';
   newImplementation: string;
+  newImplementationAbi: string;
 };
 
 type PauseParams = {
@@ -73,6 +74,7 @@ export class AdminClient extends BaseApiClient {
       type: 'upgrade',
       metadata: {
         newImplementationAddress: params.newImplementation,
+        newImplementationAbi: params.newImplementationAbi,
         proxyAdminAddress: params.proxyAdmin,
       },
       title: params.title ?? `Upgrade to ${params.newImplementation.slice(0, 10)}`,

--- a/packages/admin/src/models/proposal.ts
+++ b/packages/admin/src/models/proposal.ts
@@ -23,6 +23,7 @@ export interface ExternalApiCreateProposalRequest {
 }
 export interface ProposalMetadata {
   newImplementationAddress?: Address;
+  newImplementationAbi?: string;
   proxyAdminAddress?: Address;
   action?: 'pause' | 'unpause';
   operationType?: 'call' | 'delegateCall';


### PR DESCRIPTION
This PR adds a new field to the proposal metadata which enables users to update contract ABI within defender via an upgrade proposal. Developed in conjunction with https://github.com/OpenZeppelin/defender/pull/2933 