### PR TITLE
Hotfix: Change Axios model interceptor to ensure retro compatibility on the response

### DIFF
--- a/packages/base/src/api/api.ts
+++ b/packages/base/src/api/api.ts
@@ -17,7 +17,7 @@ export function createApi(key: string, token: string, apiUrl: string): AxiosInst
     },
   });
 
-  instance.interceptors.response.use(pick(['data']), rejectWithDefenderApiError);
+  instance.interceptors.response.use(({ data }) => data, rejectWithDefenderApiError);
 
   return instance;
 }


### PR DESCRIPTION
Fixes [this issue on the forum](https://forum.openzeppelin.com/t/api-reference-of-defender-has-stopped-returning-the-data-in-the-way-that-the-documentation-states-it/30937/2) regarding the response shape, and potentially [some other issues](https://forum.openzeppelin.com/t/defender-relay-client-ethers-issue/30947/3) with `ethersjs`