### PR TITLE
Feature: Add Access Control Proposal type

### DIFF
--- a/packages/admin/src/models/proposal.ts
+++ b/packages/admin/src/models/proposal.ts
@@ -2,7 +2,8 @@ import { Network } from 'defender-base-client';
 
 // Copied from openzeppelin/defender/models/src/types/proposal-api.req.d.ts
 export type Address = string;
-export type ProposalType = 'upgrade' | 'custom' | 'pause';
+export type Hex = string;
+export type ProposalType = 'upgrade' | 'custom' | 'pause' | 'access-control';
 export type ProposalFunctionInputs = (string | boolean | (string | boolean)[])[];
 
 export interface ExternalApiCreateProposalRequest {
@@ -25,8 +26,10 @@ export interface ProposalMetadata {
   newImplementationAddress?: Address;
   newImplementationAbi?: string;
   proxyAdminAddress?: Address;
-  action?: 'pause' | 'unpause';
+  action?: 'pause' | 'unpause' | 'grantRole' | 'revokeRole';
   operationType?: 'call' | 'delegateCall';
+  account?: Address;
+  role?: Hex;
 }
 export interface ProposalTargetFunction {
   name?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2409,13 +2409,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
 axios@^0.21.2:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
@@ -3502,7 +3495,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -3574,50 +3567,6 @@ defaults@^1.0.3:
   integrity sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==
   dependencies:
     clone "^1.0.2"
-
-defender-admin-client@1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/defender-admin-client/-/defender-admin-client-1.11.0.tgz#9d2684c597944e22c1d5a9136f71e68c832fa0c5"
-  integrity sha512-ojKNkYvpBs9NPTxQC5F/KbkZ8BIgQv3px20Ev268gLupx2cQqWgl2SOlmo/sacvO3ffXCaAZWgkR8ZtTp+j++w==
-  dependencies:
-    axios "^0.19.2"
-    defender-base-client "1.10.0"
-    lodash "^4.17.19"
-    node-fetch "^2.6.0"
-
-defender-autotask-client@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/defender-autotask-client/-/defender-autotask-client-1.10.0.tgz#1945e88603a4619a0f1cf9f182cadc34de4cad7c"
-  integrity sha512-RuyBUEDuCqeyWj594VLY/wW0J+5MFoCRny39Kzx0oxbTRVZWKUeyfXs9ats4COcYVYha90lYktnrgZDcSqo74Q==
-  dependencies:
-    axios "^0.19.2"
-    defender-base-client "1.10.0"
-    dotenv "^10.0.0"
-    glob "^7.1.6"
-    jszip "^3.5.0"
-    lodash "^4.17.19"
-    node-fetch "^2.6.0"
-
-defender-base-client@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/defender-base-client/-/defender-base-client-1.10.0.tgz#d85af9e84f57d6201e7741e44e59d5a3ff9c2b75"
-  integrity sha512-PvjJj4pWug/PVZWVi6jrdXGpykgtifGdomV1ePgZSj7cjK2mSbS0P3GUUeIzCA/d5HSV5/L6reZkI1KavnSdpA==
-  dependencies:
-    amazon-cognito-identity-js "^4.3.3"
-    axios "^0.19.2"
-    lodash "^4.17.19"
-    node-fetch "^2.6.0"
-
-defender-relay-client@1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/defender-relay-client/-/defender-relay-client-1.11.1.tgz#0ae73c1ca972f7fd082ab0c3a37301cf96a32b77"
-  integrity sha512-gz2CA45m5xho3p/nbKCVC/j07kbM/8hQajpEr+dl2YJbWRSFuxePkkd3TFKl0bya1MDZccHW8lbCQs47PQ+18w==
-  dependencies:
-    amazon-cognito-identity-js "^4.3.3"
-    axios "^0.19.2"
-    defender-base-client "1.10.0"
-    lodash "^4.17.19"
-    node-fetch "^2.6.0"
 
 defer-to-connect@^1.0.1:
   version "1.1.3"
@@ -4573,13 +4522,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.14.0:
   version "1.15.1"


### PR DESCRIPTION
## Description

Allow client to send Access Control proposal type

## Test cases

1. Create a timelock using the Defender UI on `rinkeby`
2. Use the client to create a proposal for `grantRole` using [this script](https://gist.github.com/ernestognw/cbaafa6ffde27cf2c2bad252b1591eb3)
3. Use the UI to approve and execute such proposal
4. Use the client to create a proposal for `revokeRole` using [this script](https://gist.github.com/ernestognw/a255c80cc7b66df85ee7cd1350fd1f04)
5. Use the UI to approve and execute such proposal

⚠️⚠️⚠️ WARNING

Ensure the contract address you copy into the scripts have the same format as in Defender, otherwise, https://github.com/OpenZeppelin/defender/issues/3005 might happen