### PR TITLE
Retry authentication to Cognito

### DIFF
--- a/packages/autotask-utils/package.json
+++ b/packages/autotask-utils/package.json
@@ -20,8 +20,5 @@
   ],
   "author": "Santiago Palladino <santiago@openzeppelin.com>",
   "license": "MIT",
-  "gitHead": "daddff62731a4b55075b57905d8c5b8c4eb3b80e",
-  "dependencies": {
-    "defender-sentinel-client": "1.27.1"
-  }
+  "gitHead": "daddff62731a4b55075b57905d8c5b8c4eb3b80e"
 }

--- a/packages/autotask-utils/src/types.ts
+++ b/packages/autotask-utils/src/types.ts
@@ -1,4 +1,4 @@
-import { SentinelConfirmation } from 'defender-sentinel-client/src/models/subscriber';
+export type SentinelConfirmation = number | 'safe' | 'finalized';
 
 /**
  * Event information injected by Defender when invoking an Autotask

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -21,10 +21,12 @@
   "author": "OpenZeppelin Defender <defender@openzeppelin.com>",
   "license": "MIT",
   "devDependencies": {
+    "@types/async-retry": "^1.4.4",
     "aws-sdk": "^2.733.0"
   },
   "dependencies": {
     "amazon-cognito-identity-js": "^4.3.3",
+    "async-retry": "^1.3.3",
     "axios": "^0.21.2",
     "lodash": "^4.17.19",
     "node-fetch": "^2.6.0"

--- a/packages/base/src/api/api.ts
+++ b/packages/base/src/api/api.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
-import { pick } from 'lodash/fp';
 import { DefenderApiResponseError } from './api-error';
 import { authenticate, PoolData, UserPass } from './auth';
 
@@ -18,7 +17,6 @@ export function createApi(key: string, token: string, apiUrl: string): AxiosInst
   });
 
   instance.interceptors.response.use(({ data }) => data, rejectWithDefenderApiError);
-
   return instance;
 }
 

--- a/packages/base/src/api/client.ts
+++ b/packages/base/src/api/client.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from 'axios';
 import { createAuthenticatedApi } from './api';
 
 export abstract class BaseApiClient {
-  private api: AxiosInstance | undefined;
+  private api: Promise<AxiosInstance> | undefined;
   private apiKey: string;
   private apiSecret: string;
 
@@ -18,21 +18,24 @@ export abstract class BaseApiClient {
     this.apiSecret = params.apiSecret;
   }
 
-  protected async init(): Promise<void> {
-    const userPass = { Username: this.apiKey, Password: this.apiSecret };
-    const poolData = { UserPoolId: this.getPoolId(), ClientId: this.getPoolClientId() };
-    this.api = await createAuthenticatedApi(userPass, poolData, this.getApiUrl());
+  protected async init(): Promise<AxiosInstance> {
+    if (!this.api) {
+      const userPass = { Username: this.apiKey, Password: this.apiSecret };
+      const poolData = { UserPoolId: this.getPoolId(), ClientId: this.getPoolClientId() };
+      this.api = createAuthenticatedApi(userPass, poolData, this.getApiUrl());
+    }
+    return this.api;
   }
 
   protected async apiCall<T>(fn: (api: AxiosInstance) => Promise<T>): Promise<T> {
-    if (!this.api) await this.init();
+    const api = await this.init();
     try {
-      return await fn(this.api!);
+      return await fn(api);
     } catch (error) {
       // this means ID token has expired so we'll recreate session and try again
       if (error.response.status === 401 && error.response.statusText === 'Unauthorized') {
         await this.init();
-        return await fn(this.api!);
+        return await fn(api);
       }
       throw error;
     }

--- a/packages/base/src/api/client.ts
+++ b/packages/base/src/api/client.ts
@@ -33,8 +33,9 @@ export abstract class BaseApiClient {
       return await fn(api);
     } catch (error) {
       // this means ID token has expired so we'll recreate session and try again
-      if (error.response.status === 401 && error.response.statusText === 'Unauthorized') {
-        await this.init();
+      if (error.response && error.response.status === 401 && error.response.statusText === 'Unauthorized') {
+        this.api = undefined;
+        const api = await this.init();
         return await fn(api);
       }
       throw error;

--- a/packages/relay/src/__mocks__/defender-base-client.ts
+++ b/packages/relay/src/__mocks__/defender-base-client.ts
@@ -1,9 +1,13 @@
 import { AxiosInstance } from 'axios';
 
 abstract class MockBaseApiClient extends jest.requireActual('defender-base-client').BaseApiClient {
-  private api: AxiosInstance | undefined;
-  protected async init(): Promise<void> {
-    this.api = module.exports.createAuthenticatedApi();
+  // TODO: Relayer tests are too tightly coupled with the base client implementation
+  private api: Promise<AxiosInstance> | undefined;
+  protected async init(): Promise<AxiosInstance> {
+    if (!this.api) {
+      this.api = module.exports.createAuthenticatedApi();
+    }
+    return this.api!;
   }
 }
 

--- a/packages/relay/src/test/apiRelayer.test.ts
+++ b/packages/relay/src/test/apiRelayer.test.ts
@@ -5,6 +5,9 @@ jest.mock('defender-base-client');
 jest.mock('aws-sdk');
 jest.mock('axios');
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { createAuthenticatedApi } = require('defender-base-client');
+
 type TestApiRelayer = Omit<ApiRelayer, 'api'> & {
   api: AxiosInstance;
   apiKey: string;
@@ -14,7 +17,6 @@ type TestApiRelayer = Omit<ApiRelayer, 'api'> & {
 
 describe('ApiRelayer', () => {
   let relayer: TestApiRelayer;
-  let initSpy: jest.SpyInstance<Promise<void>, []>;
   const payload = {
     to: '0x0',
     gasLimit: 21000,
@@ -22,7 +24,6 @@ describe('ApiRelayer', () => {
 
   beforeEach(async function () {
     relayer = new ApiRelayer({ apiKey: 'key', apiSecret: 'secret' }) as unknown as TestApiRelayer;
-    initSpy = jest.spyOn(relayer, 'init');
   });
 
   describe('constructor', () => {
@@ -36,7 +37,7 @@ describe('ApiRelayer', () => {
       await relayer.sendTransaction(payload);
       await relayer.sendTransaction(payload);
 
-      expect(initSpy).toBeCalledTimes(1);
+      expect(createAuthenticatedApi).toBeCalledTimes(1);
     });
 
     test('throw an init exception at the correct context', async () => {
@@ -59,7 +60,7 @@ describe('ApiRelayer', () => {
       });
       await relayer.sendTransaction(payload);
       expect(relayer.api.post).toBeCalledWith('/txs', payload);
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
 
     test('at sign', async () => {
@@ -68,7 +69,7 @@ describe('ApiRelayer', () => {
       });
       await relayer.sign({ message: '0xdead' });
       expect(relayer.api.post).toBeCalledWith('/sign', { message: '0xdead' });
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
 
     test('at query', async () => {
@@ -77,7 +78,7 @@ describe('ApiRelayer', () => {
       });
       await relayer.query('42');
       expect(relayer.api.get).toBeCalledWith('txs/42');
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
   });
 
@@ -85,7 +86,7 @@ describe('ApiRelayer', () => {
     test('passes correct arguments to the API', async () => {
       await relayer.sendTransaction(payload);
       expect(relayer.api.post).toBeCalledWith('/txs', payload);
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
   });
 
@@ -93,7 +94,7 @@ describe('ApiRelayer', () => {
     test('passes correct arguments to the API', async () => {
       await relayer.getRelayer();
       expect(relayer.api.get).toBeCalledWith('/relayer');
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
   });
 
@@ -101,7 +102,7 @@ describe('ApiRelayer', () => {
     test('passes correct arguments to the API', async () => {
       await relayer.query('42');
       expect(relayer.api.get).toBeCalledWith('txs/42');
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
   });
 
@@ -109,7 +110,7 @@ describe('ApiRelayer', () => {
     test('passes correct arguments to the API', async () => {
       await relayer.list({ limit: 10 });
       expect(relayer.api.get).toBeCalledWith('txs', { params: { limit: 10 } });
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
   });
 
@@ -117,7 +118,7 @@ describe('ApiRelayer', () => {
     test('signs a hex string', async () => {
       await relayer.sign({ message: '0xdead' });
       expect(relayer.api.post).toBeCalledWith('/sign', { message: '0xdead' });
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
   });
 
@@ -128,7 +129,7 @@ describe('ApiRelayer', () => {
         domainSeparator: '0xdead',
         hashStructMessage: '0xdead',
       });
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
   });
 
@@ -137,7 +138,7 @@ describe('ApiRelayer', () => {
       await relayer.call('eth_call', ['0xa', '0xb']);
       const payload = { jsonrpc: '2.0', id: 1, method: 'eth_call', params: ['0xa', '0xb'] };
       expect(relayer.api.post).toBeCalledWith('/relayer/jsonrpc', payload);
-      expect(initSpy).toBeCalled();
+      expect(createAuthenticatedApi).toBeCalled();
     });
   });
 });

--- a/packages/sentinel/src/__mocks__/defender-base-client.ts
+++ b/packages/sentinel/src/__mocks__/defender-base-client.ts
@@ -1,9 +1,13 @@
 import { AxiosInstance } from 'axios';
 
 abstract class MockBaseApiClient extends jest.requireActual('defender-base-client').BaseApiClient {
-  private api: AxiosInstance | undefined;
-  protected async init(): Promise<void> {
-    this.api = module.exports.createAuthenticatedApi();
+  // TODO: Sentinel tests are too tightly coupled with the base client implementation
+  private api: Promise<AxiosInstance> | undefined;
+  protected async init(): Promise<AxiosInstance> {
+    if (!this.api) {
+      this.api = module.exports.createAuthenticatedApi();
+    }
+    return this.api!;
   }
 }
 

--- a/packages/sentinel/src/api/index.test.ts
+++ b/packages/sentinel/src/api/index.test.ts
@@ -15,6 +15,7 @@ jest.mock('defender-base-client');
 jest.mock('aws-sdk');
 jest.mock('axios');
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { createAuthenticatedApi } = require('defender-base-client');
 
 type TestSentinelClient = Omit<SentinelClient, 'api'> & {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1786,6 +1786,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/async-retry@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.4.tgz#3304ce1e64f8757723f166518fc4c4b68df4fe66"
+  integrity sha512-IGT+yESLPYje0MV8MfOpT5V5oH9lAKLwlosQRyq75tYJmntkkWcfEThHLxsgYjGmYXJEY7ZZkYPb4xuW+NA6GA==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/babel__core@^7.1.7":
   version "7.1.19"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.19.tgz#7b497495b7d1b4812bdb9d02804d0576f43ee460"
@@ -1933,6 +1940,11 @@
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
+
+"@types/retry@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
+  integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
 
 "@types/secp256k1@^4.0.1":
   version "4.0.3"
@@ -2363,6 +2375,13 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+async-retry@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -8381,6 +8400,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 retry@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
We're getting reports of errors when trying to get an access token from cognito, which match some throttles on the user pool we see on AWS. This change adds a few retries to the auth request to help with that.