### PR TITLE
Add code to invoke verification through Defender's API

### DIFF
--- a/examples/verify-contract/index.js
+++ b/examples/verify-contract/index.js
@@ -25,7 +25,7 @@ async function main() {
 
   // You can get Defender to verify your compilation output matches
   // the deployed bytecode by calling `verify`
-  let verification = await client.verify({
+  let verification = await client.verifyDeployment({
     artifactUri: 'https://raw.githubusercontent.com/OpenZeppelin/defender-client/fa441208febac7f46fe7bb03c787659089315f78/examples/verify-contract/compilation-artifact.json',
     solidityFilePath: 'contracts/Vault.sol',
     contractName: 'VaultV2',
@@ -38,7 +38,7 @@ async function main() {
   // Or, if you just want to query the current verification
   // state of your contract, you can call `get` providing
   // the address and network
-  verification = await client.get({
+  verification = await client.getDeploymentVerification({
     contractAddress: '0x38e373CC414e90dDec45cf7166d497409902e998',
     contractNetwork: 'rinkeby',
   });

--- a/examples/verify-contract/index.js
+++ b/examples/verify-contract/index.js
@@ -1,0 +1,32 @@
+require('dotenv').config();
+
+const { AdminClient } = require('defender-admin-client');
+
+async function main() {
+  const creds = { apiKey: process.env.ADMIN_API_KEY, apiSecret: process.env.ADMIN_API_SECRET };
+
+  console.log('creds', creds);
+
+  const client = new AdminClient(creds);
+
+  const verification = await client.verify({
+    artifactUri: 'https://raw.githubusercontent.com/OpenZeppelin/defender-client/fa441208febac7f46fe7bb03c787659089315f78/examples/verify-contract/compilation-artifact.json',
+    solidityFilePath: 'contracts/Vault.sol',
+    contractName: 'VaultV2',
+    contractAddress: '0x38e373CC414e90dDec45cf7166d497409902e998',
+    contractNetwork: 'rinkeby'
+  });
+
+  console.log('Verification result: ', verification.matchType);
+  console.log('Compilation artifact: ', verification.artifactUri);
+  console.log('Network: ', verification.contractNetwork);
+  console.log('Contract address: ', verification.contractAddress);
+  console.log('SHA256 of bytecode on chain: ', verification.onChainSha256);
+  console.log('SHA256 of provided compilation artifact: ', verification.providedSha256);
+  console.log('Compilation artifact provided by: ', verification.providedBy);
+  console.log('Last verified: ', verification.lastVerifiedAt);  
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/examples/verify-contract/index.js
+++ b/examples/verify-contract/index.js
@@ -2,14 +2,30 @@ require('dotenv').config();
 
 const { AdminClient } = require('defender-admin-client');
 
+function printVerificationToConsole(verification) {
+  if (verification) {
+    console.log('Verification result: ', verification.matchType);
+    console.log('Compilation artifact: ', verification.artifactUri);
+    console.log('Network: ', verification.contractNetwork);
+    console.log('Contract address: ', verification.contractAddress);
+    console.log('SHA256 of bytecode on chain: ', verification.onChainSha256);
+    console.log('SHA256 of provided compilation artifact: ', verification.providedSha256);
+    console.log('Compilation artifact provided by: ', verification.providedBy);
+    console.log('Last verified: ', verification.lastVerifiedAt);
+  } else {
+    console.log('No verifications available for this contract');
+  }
+}
+
+
 async function main() {
   const creds = { apiKey: process.env.ADMIN_API_KEY, apiSecret: process.env.ADMIN_API_SECRET };
 
-  console.log('creds', creds);
-
   const client = new AdminClient(creds);
 
-  const verification = await client.verify({
+  // You can get Defender to verify your compilation output matches
+  // the deployed bytecode by calling `verify`
+  let verification = await client.verify({
     artifactUri: 'https://raw.githubusercontent.com/OpenZeppelin/defender-client/fa441208febac7f46fe7bb03c787659089315f78/examples/verify-contract/compilation-artifact.json',
     solidityFilePath: 'contracts/Vault.sol',
     contractName: 'VaultV2',
@@ -17,14 +33,17 @@ async function main() {
     contractNetwork: 'rinkeby'
   });
 
-  console.log('Verification result: ', verification.matchType);
-  console.log('Compilation artifact: ', verification.artifactUri);
-  console.log('Network: ', verification.contractNetwork);
-  console.log('Contract address: ', verification.contractAddress);
-  console.log('SHA256 of bytecode on chain: ', verification.onChainSha256);
-  console.log('SHA256 of provided compilation artifact: ', verification.providedSha256);
-  console.log('Compilation artifact provided by: ', verification.providedBy);
-  console.log('Last verified: ', verification.lastVerifiedAt);  
+  printVerificationToConsole(verification);
+
+  // Or, if you just want to query the current verification
+  // state of your contract, you can call `get` providing
+  // the address and network
+  verification = await client.get({
+    contractAddress: '0x38e373CC414e90dDec45cf7166d497409902e998',
+    contractNetwork: 'rinkeby',
+  });
+
+  printVerificationToConsole(verification);
 }
 
 if (require.main === module) {

--- a/examples/verify-contract/package.json
+++ b/examples/verify-contract/package.json
@@ -9,7 +9,7 @@
   "author": "Martin Verzilli <mverzilli@openzeppelin.com>",
   "license": "MIT",
   "dependencies": {
-    "defender-admin-client": "1.29.0",
+    "defender-admin-client": "1.28.1",
     "dotenv": "^8.2.0"
   }
 }

--- a/examples/verify-contract/package.json
+++ b/examples/verify-contract/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "example-verify-contract",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "author": "Martin Verzilli <mverzilli@openzeppelin.com>",
+  "license": "MIT",
+  "dependencies": {
+    "defender-admin-client": "1.29.0",
+    "dotenv": "^8.2.0"
+  }
+}

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -125,13 +125,15 @@ export class AdminClient extends BaseApiClient {
     return this.proposeAccessControlAction(params, contract, 'revokeRole', role, account);
   }
 
-  public async verify(params: VerificationRequest): Promise<Verification> {
+  public async verifyDeployment(params: VerificationRequest): Promise<Verification> {
     return this.apiCall(async (api) => {
       return (await api.post('/verifications', params)) as Verification;
     });
   }
 
-  public async get(params: Pick<VerificationRequest, 'contractAddress' | 'contractNetwork'>): Promise<Verification | undefined> {    
+  public async getDeploymentVerification(
+    params: Pick<VerificationRequest, 'contractAddress' | 'contractNetwork'>,
+  ): Promise<Verification | undefined> {
     return this.apiCall(async (api) => {
       try {
         return (await api.get(`/verifications/${params.contractNetwork}/${params.contractAddress}`)) as Verification;

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -4,6 +4,7 @@ import { Hex, Address, ExternalApiCreateProposalRequest as CreateProposalRequest
 import { Contract } from './models/contract';
 import { ExternalApiProposalResponse as ProposalResponse } from './models/response';
 import { getProposalUrl } from './utils';
+import { Verification, VerificationRequest } from './models/verification';
 
 type UpgradeParams = {
   title?: string;
@@ -122,6 +123,12 @@ export class AdminClient extends BaseApiClient {
     account: Address,
   ): Promise<ProposalResponseWithUrl> {
     return this.proposeAccessControlAction(params, contract, 'revokeRole', role, account);
+  }
+
+  public async verify(params: VerificationRequest): Promise<Verification> {
+    return this.apiCall(async (api) => {
+      return (await api.post('/verifications', params)) as Verification;
+    });
   }
 
   private async proposePauseabilityAction(

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -131,6 +131,16 @@ export class AdminClient extends BaseApiClient {
     });
   }
 
+  public async get(params: Pick<VerificationRequest, 'contractAddress' | 'contractNetwork'>): Promise<Verification | undefined> {    
+    return this.apiCall(async (api) => {
+      try {
+        return (await api.get(`/verifications/${params.contractNetwork}/${params.contractAddress}`)) as Verification;
+      } catch {
+        return undefined;
+      }
+    });
+  }
+
   private async proposePauseabilityAction(
     params: PauseParams,
     contract: CreateProposalRequest['contract'],

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,6 +1,7 @@
 export { AdminClient, ProposalResponseWithUrl as ProposalResponse } from './api';
 export { ExternalApiCreateProposalRequest as CreateProposalRequest } from './models/proposal';
 export { Contract } from './models/contract';
+export { VerificationRequest, Verification } from './models/verification';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 export const VERSION = require('../package.json').version;

--- a/packages/admin/src/models/verification.ts
+++ b/packages/admin/src/models/verification.ts
@@ -1,4 +1,4 @@
-// Network module comes originally from models package
+// These types are vendored from the models package
 import { Network } from 'defender-base-client';
 
 export type Address = string;
@@ -23,4 +23,5 @@ export type Verification = VerificationRequest & {
   lastVerifiedAt: string;
   matchType: 'NO_MATCH' | 'PARTIAL' | 'EXACT';
   providedBy: string;
+  providedByType: 'USER_EMAIL' | 'API_KEY'
 }

--- a/packages/admin/src/models/verification.ts
+++ b/packages/admin/src/models/verification.ts
@@ -23,5 +23,5 @@ export type Verification = VerificationRequest & {
   lastVerifiedAt: string;
   matchType: 'NO_MATCH' | 'PARTIAL' | 'EXACT';
   providedBy: string;
-  providedByType: 'USER_EMAIL' | 'API_KEY'
-}
+  providedByType: 'USER_EMAIL' | 'API_KEY';
+};

--- a/packages/admin/src/models/verification.ts
+++ b/packages/admin/src/models/verification.ts
@@ -1,0 +1,25 @@
+import { Network } from 'defender-base-client';
+
+export type Address = string;
+
+export interface VerificationRequest {
+  artifactUri: string;
+  solidityFilePath: string;
+  contractName: string;
+  contractAddress: Address;
+  contractNetwork: Network;
+}
+
+export type Verification = VerificationRequest & {
+  verificationId: string;
+  artifactUri: string;
+  solidityFilePath: string;
+  contractName: string;
+  contractAddress: Address;
+  contractNetwork: Network;
+  onChainSha256: string;
+  providedSha256: string;
+  lastVerifiedAt: string;
+  matchType: 'NO_MATCH' | 'PARTIAL' | 'EXACT';
+  providedBy: string;
+}

--- a/packages/admin/src/models/verification.ts
+++ b/packages/admin/src/models/verification.ts
@@ -1,3 +1,4 @@
+// Network module comes originally from models package
 import { Network } from 'defender-base-client';
 
 export type Address = string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3587,6 +3587,14 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+defender-admin-client@1.29.0:
+  version "1.28.1"
+  dependencies:
+    axios "^0.21.2"
+    defender-base-client "1.28.1"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
+
 defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3587,14 +3587,6 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-defender-admin-client@1.29.0:
-  version "1.28.1"
-  dependencies:
-    axios "^0.21.2"
-    defender-base-client "1.28.1"
-    lodash "^4.17.19"
-    node-fetch "^2.6.0"
-
 defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"


### PR DESCRIPTION
Ditto. Don't merge until the verification feature is released to production. 

Before merging, we also need to identify what defender-admin-client version number to use in the example (another chicken and egg problem)