### PR TITLE
Add code digest to autotask client

### DIFF
--- a/examples/update-autotask/update-code.js
+++ b/examples/update-autotask/update-code.js
@@ -8,15 +8,24 @@ async function main() {
   if (!autotaskId) throw new Error(`AutotaskId missing`);
   const { TEAM_API_KEY: apiKey, TEAM_API_SECRET: apiSecret } = process.env;
   if (!apiKey || !apiSecret) throw new Error(`Team API Key missing`);
-  console.log(apiKey)
-  console.log(apiSecret)
 
   // Setup client
   const client = new AutotaskClient({ apiKey, apiSecret });
 
-  // Update code
-  await client.updateCodeFromFolder(autotaskId, './code');
-  console.log(`Autotask code updated!`);
+  // Get new code digest
+  const code = await client.getEncodedZippedCodeFromFolder('./code');
+  const newDigest = client.getCodeDigest(code);
+
+  // Get existing one
+  const { codeDigest } = await client.get(autotaskId);
+
+  // Update code only if changed
+  if (newDigest === codeDigest) {
+    console.log(`Code digest matches (skipping upload)`);
+  } else {
+    await client.updateCodeFromFolder(autotaskId, './code');
+    console.log(`Autotask code updated`);
+  }
 }
 
 if (require.main === module) {

--- a/packages/autotask-client/src/api.ts
+++ b/packages/autotask-client/src/api.ts
@@ -1,11 +1,7 @@
+import { createHash } from 'crypto';
 import { BaseApiClient } from 'defender-base-client';
 import { CreateAutotaskRequest, UpdateAutotaskRequest } from './models/autotask';
-import {
-  AutotaskRunBase,
-  AutotaskRunErrorData,
-  AutotaskRunListResponse,
-  AutotaskRunResponse,
-} from './models/autotask-run.res';
+import { AutotaskRunBase, AutotaskRunListResponse, AutotaskRunResponse } from './models/autotask-run.res';
 import { AutotaskDeleteResponse, AutotaskListResponse, AutotaskResponse } from './models/response';
 import { zipFolder, zipSources } from './zip';
 
@@ -13,6 +9,7 @@ type SourceFiles = {
   'index.js': string;
   [name: string]: string;
 };
+
 export class AutotaskClient extends BaseApiClient {
   protected getPoolId(): string {
     return process.env.DEFENDER_AUTOTASK_POOL_ID || 'us-west-2_94f3puJWv';
@@ -99,6 +96,11 @@ export class AutotaskClient extends BaseApiClient {
     return this.apiCall(async (api) => {
       return await api.post(`/autotasks/${autotaskId}/runs/manual`, data);
     });
+  }
+
+  public getCodeDigest(encodedZippedCode: string): string {
+    const binary = Buffer.from(encodedZippedCode, 'base64');
+    return createHash('SHA256').update(binary).end().digest('base64');
   }
 
   private async updateCode(autotaskId: string, encodedZippedCode: string): Promise<void> {

--- a/packages/autotask-client/src/models/autotask.ts
+++ b/packages/autotask-client/src/models/autotask.ts
@@ -31,4 +31,5 @@ export interface Autotask extends Pick<CreateAutotaskRequest, 'name' | 'relayerI
   encodedZippedCode?: string;
   trigger: ScheduleTrigger | WebhookTrigger;
   createdAt?: string;
+  codeDigest?: string;
 }

--- a/packages/autotask-client/src/zip.ts
+++ b/packages/autotask-client/src/zip.ts
@@ -22,7 +22,9 @@ export async function zipFolder(folderPath: string): Promise<string> {
   const zip = new JSZip();
   for (const path of files) {
     const content = await promisify(readFile)(join(folderPath, path));
-    zip.file(path, content);
+    // We hardcode the date so we generate the same zip every time given the same contents
+    // This allows us to use the codedigest to decide whether or not to reupload code
+    zip.file(path, content, { date: new Date(2020, 1, 1, 0, 0, 0, 0) });
   }
 
   const zippedCode = await zip.generateAsync({ type: 'nodebuffer' });


### PR DESCRIPTION
Add new codeDigest attribute to autotasks, and add a method for generating the digest of local code, so we can decide to skip an upload if it matches the current digest.