### PR TITLE
Clarify empty newImplementationAbi assumption

### DIFF
--- a/examples/upgrade-proposal/index.js
+++ b/examples/upgrade-proposal/index.js
@@ -4,13 +4,18 @@ const { AdminClient } = require('defender-admin-client');
 
 const proxy = '0xB07b1C80371915dEFd254d1C57BeF2bDe6D3b610';
 const newImplementation = '0x86690db6c757fcc71ff1b69cf24529e5ab6481fb';
+const newImplementationAbi =
+  '[{"inputs":[{"internalType":"string","name":"newValue","type":"string"}],"name":"changeValue","outputs":[],"stateMutability":"nonpayable","type":"function"}]'; // If no newImplementationAbi is provided the previous implementation ABI will be assumed
 const network = 'rinkeby';
 
 async function main() {
   const creds = { apiKey: process.env.ADMIN_API_KEY, apiSecret: process.env.ADMIN_API_SECRET };
   const client = new AdminClient(creds);
 
-  const proposal = await client.proposeUpgrade({ newImplementation }, { network, address: proxy });
+  const proposal = await client.proposeUpgrade(
+    { newImplementation, newImplementationAbi },
+    { network, address: proxy },
+  );
   const siteUrl = process.env.SITE_URL || 'https://defender.openzeppelin.com';
   console.log(`${siteUrl}/#/admin/contracts/${proposal.contractId}/proposals/${proposal.proposalId}`);
 }

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -57,12 +57,13 @@ Note that this can potentially brick your multisig, if the contract you delegate
 
 ### Upgrade proposals
 
-To create an `upgrade` action proposal, just provide the proxy contract network and address, along with the new implementation address, and Defender will automatically resolve the rest:
+To create an `upgrade` action proposal, provide the proxy contract network and address, along with the new implementation address, and Defender will automatically resolve the rest (note that if no newImplementationAbi is provided the previous implementation ABI will be assumed for the proposal):
 
 ```js
 const newImplementation = '0x3E5e9111Ae8eB78Fe1CC3bb8915d5D461F3Ef9A9';
+const newImplementationAbi = '[...]'
 const contract = { network: 'rinkeby', address: '0x28a8746e75304c0780E011BEd21C72cD78cd535E' };
-await client.proposeUpgrade({ newImplementation }, contract);
+await client.proposeUpgrade({ newImplementation, newImplementationAbi }, contract);
 ```
 
 If your proxies do not implement the [EIP1967 admin slot](https://eips.ethereum.org/EIPS/eip-1967#admin-address), you will need to provide either the [`ProxyAdmin` contract](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.0.0/contracts/proxy/transparent/ProxyAdmin.sol) or the Account with rights to execute the upgrade, as shown below.
@@ -72,8 +73,9 @@ If your proxies do not implement the [EIP1967 admin slot](https://eips.ethereum.
 ```js
 const newImplementation = '0x3E5e9111Ae8eB78Fe1CC3bb8915d5D461F3Ef9A9';
 const proxyAdmin = '0x2fC100f1BeA4ACCD5dA5e5ed725D763c90e8ca96';
+const newImplementationAbi = '[...]'
 const contract = { network: 'rinkeby', address: '0x28a8746e75304c0780E011BEd21C72cD78cd535E' };
-await client.proposeUpgrade({ newImplementation, proxyAdmin }, contract);
+await client.proposeUpgrade({ newImplementation, newImplementationAbi, proxyAdmin }, contract);
 ```
 
 #### Explicit owner account
@@ -83,7 +85,8 @@ const newImplementation = '0x3E5e9111Ae8eB78Fe1CC3bb8915d5D461F3Ef9A9';
 const via = '0xF608FA64c4fF8aDdbEd106E69f3459effb4bC3D1';
 const viaType = 'Gnosis Safe'; // or 'Gnosis Multisig', or 'EOA'
 const contract = { network: 'rinkeby', address: '0x28a8746e75304c0780E011BEd21C72cD78cd535E' };
-await client.proposeUpgrade({ newImplementation, via, viaType }, contract);
+const newImplementationAbi = '[...]'
+await client.proposeUpgrade({ newImplementation, newImplementationAbi, via, viaType }, contract);
 ```
 
 ### Pause proposals


### PR DESCRIPTION
Add details about the newImplementationAbi, if not provided the previous implementation ABI will be assumed.

Context: 
Forum Issue where using defender-client to create a proposal without an newImplementationAbi would prevent querying contract state after execution.

https://forum.openzeppelin.com/t/defender-ui-stuck-on-querying-contract-and-pausability-state-after-accepting-arbitrum-rinkeby-upgrade-proposal/31291/15