### PR TITLE
Proposal archivals via API

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -110,7 +110,16 @@ You can list all proposals:
 const proposals = await client.listProposals();
 ```
 
-You can filter your active proposals by `isActive` property present on each proposal in the list response.
+You can filter your active proposals by `isActive` property present on each proposal in the list response. By default, only unarchived proposals are returned, but you can override this by adding an `includeArchived: true` option in the call.
+
+### Archiving proposals
+
+You can archive or unarchive a proposal given its contract and proposal ids:
+
+```js
+await client.archiveProposal(contractId, proposalId);
+await client.unarchiveProposal(contractId, proposalId);
+```
 
 ## Adding Contracts
 

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -72,10 +72,28 @@ export class AdminClient extends BaseApiClient {
     });
   }
 
-  public async listProposals(): Promise<ProposalResponseWithUrl[]> {
+  public async listProposals(opts: { includeArchived?: boolean } = {}): Promise<ProposalResponseWithUrl[]> {
     return this.apiCall(async (api) => {
-      const response = (await api.get('/proposals')) as ProposalResponse[];
+      const response = (await api.get('/proposals', { params: opts })) as ProposalResponse[];
       return response.map((proposal) => ({ ...proposal, url: getProposalUrl(proposal) }));
+    });
+  }
+
+  public async archiveProposal(contractId: string, proposalId: string): Promise<ProposalResponseWithUrl> {
+    return this.apiCall(async (api) => {
+      const response = (await api.put(`/contracts/${contractId}/proposals/${proposalId}/archived`, {
+        archived: true,
+      })) as ProposalResponse;
+      return { ...response, url: getProposalUrl(response) };
+    });
+  }
+
+  public async unarchiveProposal(contractId: string, proposalId: string): Promise<ProposalResponseWithUrl> {
+    return this.apiCall(async (api) => {
+      const response = (await api.put(`/contracts/${contractId}/proposals/${proposalId}/archived`, {
+        archived: false,
+      })) as ProposalResponse;
+      return { ...response, url: getProposalUrl(response) };
     });
   }
 

--- a/packages/admin/src/models/response.ts
+++ b/packages/admin/src/models/response.ts
@@ -5,4 +5,5 @@ export interface ExternalApiProposalResponse extends ExternalApiCreateProposalRe
   proposalId: string;
   createdAt: string;
   isActive: boolean;
+  isArchived: boolean;
 }


### PR DESCRIPTION
- Adds an `isArchived` flag to the proposals returned via API
- Adds an `includeArchived` option to the proposal list method
- Adds a new method for archiving and unarchiving a proposal via API

Requires https://github.com/OpenZeppelin/defender/pull/3175