### PR TITLE
add force-publish tag to release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn run lerna publish v1.3.0-rc.4 --preid rc --dist-tag next --pre-dist-tag nex
 And to publish the final release:
 
 ```
-yarn run lerna publish --exact
+yarn run lerna publish --exact --force-publish
 ```
 
 ## Examples


### PR DESCRIPTION
I've run into issues these last 2 releases because I attempted to follow our README exactly (without `--force-publish`). The sequence was roughly (with slight variation): 

* There were a few commits pushed to `defender-client`
* I published a RC version to `next` using instructions on the README
* There were no more changes to the package
* I attempted to publish to prod with `yarn run lerna publish --exact` and it refused to publish anything because there were no changes since the last publish

The `--force-publish` tag causes lerna to skip change detection, which ends up publishing all client packages (even if some of them have no changes). I kind of like them versioning together, but I can see a case for doing otherwise.

There are probably other ways to revise our publishing process and I'm open to other ideas, but the README steps do not work as is, so we need to make a change.