### PR TITLE
Fix import, so it works in the publised package

### DIFF
--- a/packages/sentinel/src/models/blockwatcher.ts
+++ b/packages/sentinel/src/models/blockwatcher.ts
@@ -1,5 +1,5 @@
 import { Network } from 'defender-base-client';
-import { SentinelConfirmation } from 'defender-sentinel-client/src/models/subscriber';
+import { SentinelConfirmation } from './subscriber';
 export interface BlockWatcherOptions {
   processBlockAttempts?: number;
   processBlockAttemptTimeoutMs?: number;


### PR DESCRIPTION
Getting this error otherwise:
```
node_modules/defender-sentinel-client/lib/models/blockwatcher.d.ts:2:38 - error TS2307: Cannot find module 'defender-sentinel-client/src/models/subscriber' or its corresponding type declarations.

2 import { SentinelConfirmation } from 'defender-sentinel-client/src/models/subscriber';
```