### PR TITLE
Rate limit lambda execution

### DIFF
--- a/packages/base/src/autotask/index.ts
+++ b/packages/base/src/autotask/index.ts
@@ -44,18 +44,15 @@ export abstract class BaseAutotaskClient {
     const invocationTimeStamp = getTimestampInSeconds();
 
     this.invocationRateLimit.checkRateFor(invocationTimeStamp);
+    this.invocationRateLimit.incrementRateFor(invocationTimeStamp);
 
-    const invocationRequest = this.lambda
+    const invocationRequestResult = await this.lambda
       .invoke({
         FunctionName: this.arn,
         Payload: JSON.stringify(request),
         InvocationType: 'RequestResponse',
       })
       .promise();
-
-    this.invocationRateLimit.incrementRateFor(invocationTimeStamp);
-
-    const invocationRequestResult = await invocationRequest;
 
     if (invocationRequestResult.FunctionError) {
       throw new Error(`Error while attempting request: ${cleanError(invocationRequestResult.Payload)}`);

--- a/packages/base/src/autotask/index.ts
+++ b/packages/base/src/autotask/index.ts
@@ -24,7 +24,8 @@ export abstract class BaseAutotaskClient {
   public constructor(credentials: string, private arn: string) {
     const creds = credentials ? JSON.parse(credentials) : undefined;
 
-    this.invocationRateLimit = rateLimitModule.createCounterFor(arn, 10);
+    this.invocationRateLimit = rateLimitModule.createCounterFor(arn, 300);
+
     this.lambda = new Lambda(
       creds
         ? {

--- a/packages/base/src/autotask/index.ts
+++ b/packages/base/src/autotask/index.ts
@@ -1,4 +1,6 @@
 import Lambda, { _Blob } from 'aws-sdk/clients/lambda';
+import { rateLimitModule, RateLimitModule } from '../utils/rate-limit';
+import { getTimestampInSeconds } from '../utils/time';
 
 // do our best to get .errorMessage, but return object by default
 function cleanError(payload?: _Blob): _Blob {
@@ -17,8 +19,12 @@ function cleanError(payload?: _Blob): _Blob {
 export abstract class BaseAutotaskClient {
   private lambda: Lambda;
 
+  private invocationRateLimit: RateLimitModule;
+
   public constructor(credentials: string, private arn: string) {
     const creds = credentials ? JSON.parse(credentials) : undefined;
+
+    this.invocationRateLimit = rateLimitModule.createCounterFor(arn, 10);
     this.lambda = new Lambda(
       creds
         ? {
@@ -34,7 +40,11 @@ export abstract class BaseAutotaskClient {
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   protected async execute<T>(request: object): Promise<T> {
-    const result = await this.lambda
+    const invocationTimeStamp = getTimestampInSeconds();
+
+    this.invocationRateLimit.checkRateFor(invocationTimeStamp);
+
+    const invocationRequest = this.lambda
       .invoke({
         FunctionName: this.arn,
         Payload: JSON.stringify(request),
@@ -42,10 +52,14 @@ export abstract class BaseAutotaskClient {
       })
       .promise();
 
-    if (result.FunctionError) {
-      throw new Error(`Error while attempting request: ${cleanError(result.Payload)}`);
+    this.invocationRateLimit.incrementRateFor(invocationTimeStamp);
+
+    const invocationRequestResult = await invocationRequest;
+
+    if (invocationRequestResult.FunctionError) {
+      throw new Error(`Error while attempting request: ${cleanError(invocationRequestResult.Payload)}`);
     }
 
-    return JSON.parse(result.Payload as string) as T;
+    return JSON.parse(invocationRequestResult.Payload as string) as T;
   }
 }

--- a/packages/base/src/utils/rate-limit.test.ts
+++ b/packages/base/src/utils/rate-limit.test.ts
@@ -12,6 +12,8 @@ describe('utils/rate-limit', () => {
       rateLimit.incrementRateFor(rateEntryName);
 
       rateLimit.checkRateFor(rateEntryName);
+
+      fail('Should have errored');
     } catch (error) {
       expect(error.message).toBe('Rate limit exceeded');
     }

--- a/packages/base/src/utils/rate-limit.test.ts
+++ b/packages/base/src/utils/rate-limit.test.ts
@@ -1,0 +1,30 @@
+import { rateLimitModule } from './rate-limit';
+
+describe('utils/rate-limit', () => {
+  test('should throw error if limit is reached', () => {
+    try {
+      const rateLimit = rateLimitModule.createCounterFor('test1', 2);
+
+      const rateEntryName = 1;
+
+      rateLimit.incrementRateFor(rateEntryName);
+      rateLimit.incrementRateFor(rateEntryName);
+      rateLimit.incrementRateFor(rateEntryName);
+
+      rateLimit.checkRateFor(rateEntryName);
+    } catch (error) {
+      expect(error.message).toBe('Rate limit exceeded');
+    }
+  });
+
+  test('should increment rate for entry', () => {
+    const rateLimit = rateLimitModule.createCounterFor('test2', 2);
+
+    const rateEntryName = 1;
+
+    rateLimit.incrementRateFor(rateEntryName);
+    rateLimit.incrementRateFor(rateEntryName);
+
+    expect(rateLimit.getRateFor(rateEntryName)).toBe(2);
+  });
+});

--- a/packages/base/src/utils/rate-limit.ts
+++ b/packages/base/src/utils/rate-limit.ts
@@ -15,7 +15,7 @@ const createRateLimitModule = () => {
         checkRateFor: (rateEntry: unknown) => {
           const currentSecondNumberOfRequests = rateLimitForIdentifier.get(rateEntry) || 0;
 
-          if (currentSecondNumberOfRequests > rateLimit) throw new Error('Rate limit exceeded');
+          if (currentSecondNumberOfRequests >= rateLimit) throw new Error('Rate limit exceeded');
 
           return currentSecondNumberOfRequests;
         },

--- a/packages/base/src/utils/rate-limit.ts
+++ b/packages/base/src/utils/rate-limit.ts
@@ -5,20 +5,23 @@ const createRateLimitModule = () => {
 
   return {
     createCounterFor: (toLimitIdentifier: string, rateLimit: number) => {
-      const hasAlreadyACounter = globalCounter[toLimitIdentifier];
+      const hasAlreadyACounter = Boolean(globalCounter[toLimitIdentifier]);
       if (!hasAlreadyACounter) globalCounter[toLimitIdentifier] = new Map();
 
-      return {
-        checkRateFor: (rateEntry: unknown) => {
-          const currentSecondNumberOfRequests = globalCounter[toLimitIdentifier].get(rateEntry) || 0;
+      const rateLimitForIdentifier = globalCounter[toLimitIdentifier];
 
-          if (currentSecondNumberOfRequests > rateLimit) throw new Error('Too many requests');
+      return {
+        getRateFor: (rateEntry: unknown) => rateLimitForIdentifier.get(rateEntry) || 0,
+        checkRateFor: (rateEntry: unknown) => {
+          const currentSecondNumberOfRequests = rateLimitForIdentifier.get(rateEntry) || 0;
+
+          if (currentSecondNumberOfRequests > rateLimit) throw new Error('Rate limit exceeded');
 
           return currentSecondNumberOfRequests;
         },
         incrementRateFor: (rateEntry: unknown) => {
-          const newRateCount = (globalCounter[toLimitIdentifier].get(rateEntry) || 0) + 1;
-          globalCounter[toLimitIdentifier].set(rateEntry, newRateCount);
+          const newRateCount = (rateLimitForIdentifier.get(rateEntry) || 0) + 1;
+          rateLimitForIdentifier.set(rateEntry, newRateCount);
 
           return newRateCount;
         },

--- a/packages/base/src/utils/rate-limit.ts
+++ b/packages/base/src/utils/rate-limit.ts
@@ -1,0 +1,35 @@
+type GlobalCounter = Record<string, Map<unknown, number>>;
+
+const createRateLimitModule = () => {
+  const globalCounter: GlobalCounter = {};
+
+  return {
+    createCounterFor: (toLimitIdentifier: string, rateLimit: number) => {
+      const hasAlreadyACounter = globalCounter[toLimitIdentifier];
+      if (!hasAlreadyACounter) globalCounter[toLimitIdentifier] = new Map();
+
+      return {
+        checkRateFor: (rateEntry: unknown) => {
+          const currentSecondNumberOfRequests = globalCounter[toLimitIdentifier].get(rateEntry) || 0;
+
+          if (currentSecondNumberOfRequests > rateLimit) throw new Error('Too many requests');
+
+          return currentSecondNumberOfRequests;
+        },
+        incrementRateFor: (rateEntry: unknown) => {
+          const newRateCount = (globalCounter[toLimitIdentifier].get(rateEntry) || 0) + 1;
+          globalCounter[toLimitIdentifier].set(rateEntry, newRateCount);
+
+          return newRateCount;
+        },
+      };
+    },
+  };
+};
+
+export type RateLimitModule = {
+  checkRateFor: (currentTimeStamp: number) => number;
+  incrementRateFor: (currentTimeStamp: number) => number;
+};
+
+export const rateLimitModule = createRateLimitModule();

--- a/packages/base/src/utils/rate-limit.ts
+++ b/packages/base/src/utils/rate-limit.ts
@@ -15,7 +15,7 @@ const createRateLimitModule = () => {
         checkRateFor: (rateEntry: unknown) => {
           const currentSecondNumberOfRequests = rateLimitForIdentifier.get(rateEntry) || 0;
 
-          if (currentSecondNumberOfRequests >= rateLimit) throw new Error('Rate limit exceeded');
+          if (currentSecondNumberOfRequests > rateLimit) throw new Error('Rate limit exceeded');
 
           return currentSecondNumberOfRequests;
         },

--- a/packages/base/src/utils/time.ts
+++ b/packages/base/src/utils/time.ts
@@ -1,0 +1,1 @@
+export const getTimestampInSeconds = (): number => Math.floor(Date.now() / 1000);

--- a/packages/relay/src/autotask/index-rate.test.ts
+++ b/packages/relay/src/autotask/index-rate.test.ts
@@ -37,18 +37,18 @@ describe('AutotaskRelayer', () => {
 
   describe('get rate limited', () => {
     test('throw Rate limit error after 300 requests', async () => {
-      const executionalLimit = 300;
+      const rateLimit = 300;
 
       await waitNextSecondStart();
 
       let hasBeenRateLimited = false;
 
       await Promise.all(
-        Array.from({ length: 301 }).map(async (ignore, index) => {
+        Array.from({ length: 302 }).map(async (ignore, index) => {
           try {
             await relayer.query('42');
           } catch (error) {
-            expect(index).toBe(executionalLimit);
+            expect(index).toBe(rateLimit + 1);
             expect(error.message).toBe('Rate limit exceeded');
             hasBeenRateLimited = true;
           }

--- a/packages/relay/src/autotask/index-rate.test.ts
+++ b/packages/relay/src/autotask/index-rate.test.ts
@@ -1,0 +1,40 @@
+import { AutotaskRelayer } from '.';
+import Lambda from 'aws-sdk/clients/lambda';
+
+type TestAutotaskRelayer = Omit<AutotaskRelayer, 'lambda' | 'relayerARN'> & { lambda: Lambda; arn: string };
+
+describe('AutotaskRelayer', () => {
+  const credentials = {
+    AccessKeyId: 'keyId',
+    SecretAccessKey: 'accessKey',
+    SessionToken: 'token',
+  };
+
+  let relayer: TestAutotaskRelayer;
+
+  beforeEach(async function () {
+    relayer = new AutotaskRelayer({
+      credentials: JSON.stringify(credentials),
+      relayerARN: 'arn',
+    }) as unknown as TestAutotaskRelayer;
+  });
+
+  afterAll(() => {
+    expect(true).toBe(false);
+  });
+
+  describe('get rate limited', () => {
+    test('passes correct arguments to the API', async () => {
+      await Promise.all(
+        Array.from({ length: 301 }).map(async (ignore, index) => {
+          try {
+            await relayer.query('42');
+          } catch (error) {
+            expect(index).toBe(301);
+            expect(error.message).toBe('Rate limit exceeded');
+          }
+        }),
+      );
+    });
+  });
+});

--- a/packages/relay/src/autotask/index.test.ts
+++ b/packages/relay/src/autotask/index.test.ts
@@ -24,6 +24,10 @@ describe('AutotaskRelayer', () => {
     }) as unknown as TestAutotaskRelayer;
   });
 
+  afterAll(() => {
+    expect(true).toBe(false);
+  });
+
   describe('constructor', () => {
     test('calls init', () => {
       expect(relayer.arn).toBe('arn');


### PR DESCRIPTION
Include a temporary client-side rate limit to prevent over-executing relayer lambda.