### PR TITLE
Support Relayer as a proposal execution strategy

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -175,6 +175,24 @@ await client.createProposal({
 });
 ```
 
+### Relayer Execution Strategy
+
+To use a relayer as an execution strategy you need to provide the `relayerId` as well as setting `via` to the relayer address and `viaType: 'Relayer'`
+
+```js
+const contract = { network: 'goerli', address: '0xC73dAd1D9a356Ab2F3c6bC0049034aFe4B59DbB5' };
+
+const proposal = await client.proposePause(
+  {
+    title: 'Pause contract',
+    via: '0x6b74fa33f198a65fe374c8146387f1653d190c7a',
+    viaType: 'Relayer',
+    relayerId: 'dfa8b9a9-0f88-4d38-892a-93e1f5a8d2a7',
+  },
+  contract,
+);
+```
+
 ### List proposals
 
 You can list all proposals:

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -14,6 +14,7 @@ type UpgradeParams = {
   viaType?: CreateProposalRequest['viaType'];
   newImplementation: string;
   newImplementationAbi?: string;
+  relayerId?: string;
 };
 
 type PauseParams = {
@@ -21,6 +22,7 @@ type PauseParams = {
   description?: string;
   via: Address;
   viaType: CreateProposalRequest['viaType'];
+  relayerId?: string;
 };
 
 type AccessControlParams = {
@@ -28,6 +30,7 @@ type AccessControlParams = {
   description?: string;
   via: Address;
   viaType: CreateProposalRequest['viaType'];
+  relayerId?: string;
 };
 
 export interface ProposalResponseWithUrl extends ProposalResponse {
@@ -120,6 +123,7 @@ export class AdminClient extends BaseApiClient {
       description: params.description ?? `Upgrade contract implementation to ${params.newImplementation}`,
       via: params.via,
       viaType: params.viaType,
+      relayerId: params.relayerId,
     };
     return this.createProposal(request);
   }
@@ -189,6 +193,7 @@ export class AdminClient extends BaseApiClient {
       type: 'pause',
       via: params.via,
       viaType: params.viaType,
+      relayerId: params.relayerId,
       functionInputs: [],
       functionInterface: { name: action, inputs: [] },
       metadata: {
@@ -212,6 +217,7 @@ export class AdminClient extends BaseApiClient {
       type: 'access-control',
       via: params.via,
       viaType: params.viaType,
+      relayerId: params.relayerId,
       functionInputs: [role, account],
       functionInterface: {
         name: action,

--- a/packages/admin/src/models/proposal.ts
+++ b/packages/admin/src/models/proposal.ts
@@ -16,10 +16,11 @@ export interface ExternalApiCreateProposalRequest {
   type: ProposalType;
   metadata?: ProposalMetadata;
   via?: Address;
-  viaType?: 'EOA' | 'Gnosis Safe' | 'Gnosis Multisig';
+  viaType?: 'EOA' | 'Gnosis Safe' | 'Gnosis Multisig' | 'Relayer';
   functionInterface?: ProposalTargetFunction;
   functionInputs?: ProposalFunctionInputs;
   steps?: ProposalStep[];
+  relayerId?: string;
 }
 
 export interface PartialContract {


### PR DESCRIPTION
Defender will soon support relayer as an execution strategy, this PR adds the required changes to the admin client