### PR TITLE
add simulate flag to createProposal request

### DIFF
--- a/examples/simulate-proposal/index.js
+++ b/examples/simulate-proposal/index.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 
 const { AdminClient } = require('defender-admin-client');
-const { utils } = require('ethers')
+const { utils } = require('ethers');
 
 const contractABI = require('./abi/demoflash.json');
 
@@ -34,10 +34,10 @@ async function main() {
     viaType: 'EOA',
   });
 
-  console.log(`Created proposal (${proposal.proposalId})`)
+  console.log(`Created proposal (${proposal.proposalId})`);
+
 
   const contractInterface = new utils.Interface(contractABI);
-
   // encode function data
   const data = contractInterface.encodeFunctionData(proposal.functionInterface.name, proposal.functionInputs)
 
@@ -60,8 +60,8 @@ async function main() {
       }
     );
 
-    // Check if simulation reverted under `simulation.meta.reverted` 
-    // and the reason string `simulation.meta.returnString`
+    // Check if simulation reverted under`simulation.meta.reverted` 
+    // and the reason string`simulation.meta.returnString`
     if (simulation.meta.reverted) {
       console.log("Transaction reverted:", simulation.meta.returnString ?? simulation.meta.returnValue)
     } else {
@@ -74,6 +74,43 @@ async function main() {
       console.error(e);
     }
   }
+
+  // Alternatively you can initiate a simulation request as part of `createProposal`
+  const proposalWithSimulation = await client.createProposal({
+    contract: {
+      address: '0xA91382E82fB676d4c935E601305E5253b3829dCD',
+      network: 'mainnet',
+      abi: JSON.stringify(contractABI), // provide this OR overrideSimulationOpts.transactionData.data
+    },
+    title: 'Flash',
+    description: 'Call the Flash() function',
+    type: 'custom',
+    metadata: {
+      sendTo: "0xA91382E82fB676d4c935E601305E5253b3829dCD",
+      sendValue: "10000000000000000",
+      sendCurrency: {
+        name: "Ethereum",
+        symbol: "ETH",
+        decimals: 18,
+        type: 'native',
+      },
+    },
+    functionInterface: { name: 'flash', inputs: [] },
+    functionInputs: [],
+    via: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    viaType: 'EOA',
+    simulate: true, // set this to true
+    // optional
+    overrideSimulationOpts: {
+      transactionData: {
+        data: "0xd336c82d" // or instead of ABI, you can provide this
+      }
+    }
+  });
+
+  console.log(`Created proposal (${proposalWithSimulation.proposalId})`);
+  console.log(proposalWithSimulation.simulation);
+
 }
 
 if (require.main === module) {

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -40,6 +40,43 @@ await client.createProposal({
 });
 ```
 
+You can also optionally set the `simulate` flag to simulate the proposal within the same request. You can override simulation parameters by setting the `overrideSimulationOpts` property, which is a `SimulationRequest` object.
+
+```js
+const proposalWithSimulation = await client.createProposal({
+  contract: {
+    address: '0xA91382E82fB676d4c935E601305E5253b3829dCD',
+    network: 'mainnet',
+    // provide this OR overrideSimulationOpts.transactionData.data
+    abi: JSON.stringify(contractABI),
+  },
+  title: 'Flash',
+  description: 'Call the Flash() function',
+  type: 'custom',
+  metadata: {
+    sendTo: '0xA91382E82fB676d4c935E601305E5253b3829dCD',
+    sendValue: '10000000000000000',
+    sendCurrency: {
+      name: 'Ethereum',
+      symbol: 'ETH',
+      decimals: 18,
+      type: 'native',
+    },
+  },
+  functionInterface: { name: 'flash', inputs: [] },
+  functionInputs: [],
+  via: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+  viaType: 'EOA',
+  simulate: true, // set this to true
+  // optional
+  overrideSimulationOpts: {
+    transactionData: {
+      data: '0xd336c82d', // or instead of ABI, you can provide this
+    },
+  },
+});
+```
+
 #### Issuing DELEGATECALLs
 
 When invoking a function via a Gnosis Safe, it's possible to call it via a `DELEGATECALL` instruction instead of a regular call. This has the effect of executing the code in the called contract _in the context of the multisig_, meaning any operations that affect storage will affect the multisig, and any calls to additional contracts will be executed as if the `msg.sender` were the multisig. To do this, add a `metadata` parameter with the value `{ operationType: 'delegateCall' }` to your `createProposal` call:

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -24,7 +24,8 @@
     "axios": "^0.21.2",
     "defender-base-client": "1.37.0",
     "lodash": "^4.17.19",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "ethers": "^5.7.2"
   },
   "gitHead": "a7c4808dd11e708df42d110de230c264061c72c3"
 }


### PR DESCRIPTION
This PR adds an optional `simulate` flag to the `createProposal` request in defender-client.