### PR TITLE
feat: allow ability to pass a http agent over to defender

### DIFF
--- a/packages/base/src/api/api.ts
+++ b/packages/base/src/api/api.ts
@@ -7,7 +7,7 @@ export function rejectWithDefenderApiError(axiosError: AxiosError): Promise<neve
   return Promise.reject(new DefenderApiResponseError(axiosError));
 }
 
-export function createApi(key: string, token: string, apiUrl: string, httpAgent?: https.Agent): AxiosInstance {
+export function createApi(key: string, token: string, apiUrl: string, httpsAgent?: https.Agent): AxiosInstance {
   const instance = axios.create({
     baseURL: apiUrl,
     headers: {
@@ -15,7 +15,7 @@ export function createApi(key: string, token: string, apiUrl: string, httpAgent?
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-    httpAgent,
+    httpsAgent,
   });
 
   instance.interceptors.response.use(({ data }) => data, rejectWithDefenderApiError);
@@ -26,9 +26,9 @@ export async function createAuthenticatedApi(
   userPass: UserPass,
   poolData: PoolData,
   apiUrl: string,
-  httpAgent?: https.Agent,
+  httpsAgent?: https.Agent,
 ): Promise<AxiosInstance> {
   const token = await authenticate(userPass, poolData);
-  const api = createApi(userPass.Username, token, apiUrl, httpAgent);
+  const api = createApi(userPass.Username, token, apiUrl, httpsAgent);
   return api;
 }

--- a/packages/base/src/api/api.ts
+++ b/packages/base/src/api/api.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
+import https from 'https';
 import { DefenderApiResponseError } from './api-error';
 import { authenticate, PoolData, UserPass } from './auth';
 
@@ -6,7 +7,7 @@ export function rejectWithDefenderApiError(axiosError: AxiosError): Promise<neve
   return Promise.reject(new DefenderApiResponseError(axiosError));
 }
 
-export function createApi(key: string, token: string, apiUrl: string): AxiosInstance {
+export function createApi(key: string, token: string, apiUrl: string, httpAgent?: https.Agent): AxiosInstance {
   const instance = axios.create({
     baseURL: apiUrl,
     headers: {
@@ -14,6 +15,7 @@ export function createApi(key: string, token: string, apiUrl: string): AxiosInst
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
+    httpAgent,
   });
 
   instance.interceptors.response.use(({ data }) => data, rejectWithDefenderApiError);
@@ -24,8 +26,9 @@ export async function createAuthenticatedApi(
   userPass: UserPass,
   poolData: PoolData,
   apiUrl: string,
+  httpAgent?: https.Agent,
 ): Promise<AxiosInstance> {
   const token = await authenticate(userPass, poolData);
-  const api = createApi(userPass.Username, token, apiUrl);
+  const api = createApi(userPass.Username, token, apiUrl, httpAgent);
   return api;
 }

--- a/packages/base/src/api/client.ts
+++ b/packages/base/src/api/client.ts
@@ -6,26 +6,26 @@ export abstract class BaseApiClient {
   private api: Promise<AxiosInstance> | undefined;
   private apiKey: string;
   private apiSecret: string;
-  private httpAgent?: https.Agent;
+  private httpsAgent?: https.Agent;
 
   protected abstract getPoolId(): string;
   protected abstract getPoolClientId(): string;
   protected abstract getApiUrl(): string;
 
-  public constructor(params: { apiKey: string; apiSecret: string; httpAgent?: https.Agent }) {
+  public constructor(params: { apiKey: string; apiSecret: string; httpsAgent?: https.Agent }) {
     if (!params.apiKey) throw new Error(`API key is required`);
     if (!params.apiSecret) throw new Error(`API secret is required`);
 
     this.apiKey = params.apiKey;
     this.apiSecret = params.apiSecret;
-    this.httpAgent = params.httpAgent;
+    this.httpsAgent = params.httpsAgent;
   }
 
   protected async init(): Promise<AxiosInstance> {
     if (!this.api) {
       const userPass = { Username: this.apiKey, Password: this.apiSecret };
       const poolData = { UserPoolId: this.getPoolId(), ClientId: this.getPoolClientId() };
-      this.api = createAuthenticatedApi(userPass, poolData, this.getApiUrl(), this.httpAgent);
+      this.api = createAuthenticatedApi(userPass, poolData, this.getApiUrl(), this.httpsAgent);
     }
     return this.api;
   }

--- a/packages/base/src/api/client.ts
+++ b/packages/base/src/api/client.ts
@@ -5,24 +5,26 @@ export abstract class BaseApiClient {
   private api: Promise<AxiosInstance> | undefined;
   private apiKey: string;
   private apiSecret: string;
+  private httpAgent?: AxiosInstance;
 
   protected abstract getPoolId(): string;
   protected abstract getPoolClientId(): string;
   protected abstract getApiUrl(): string;
 
-  public constructor(params: { apiKey: string; apiSecret: string }) {
+  public constructor(params: { apiKey: string; apiSecret: string; httpAgent?: AxiosInstance }) {
     if (!params.apiKey) throw new Error(`API key is required`);
     if (!params.apiSecret) throw new Error(`API secret is required`);
 
     this.apiKey = params.apiKey;
     this.apiSecret = params.apiSecret;
+    this.httpAgent = params.httpAgent;
   }
 
   protected async init(): Promise<AxiosInstance> {
     if (!this.api) {
       const userPass = { Username: this.apiKey, Password: this.apiSecret };
       const poolData = { UserPoolId: this.getPoolId(), ClientId: this.getPoolClientId() };
-      this.api = createAuthenticatedApi(userPass, poolData, this.getApiUrl());
+      this.api = createAuthenticatedApi(userPass, poolData, this.getApiUrl(), this.httpAgent);
     }
     return this.api;
   }

--- a/packages/base/src/api/client.ts
+++ b/packages/base/src/api/client.ts
@@ -1,17 +1,18 @@
 import { AxiosInstance } from 'axios';
+import https from 'https';
 import { createAuthenticatedApi } from './api';
 
 export abstract class BaseApiClient {
   private api: Promise<AxiosInstance> | undefined;
   private apiKey: string;
   private apiSecret: string;
-  private httpAgent?: AxiosInstance;
+  private httpAgent?: https.Agent;
 
   protected abstract getPoolId(): string;
   protected abstract getPoolClientId(): string;
   protected abstract getApiUrl(): string;
 
-  public constructor(params: { apiKey: string; apiSecret: string; httpAgent?: AxiosInstance }) {
+  public constructor(params: { apiKey: string; apiSecret: string; httpAgent?: https.Agent }) {
     if (!params.apiKey) throw new Error(`API key is required`);
     if (!params.apiSecret) throw new Error(`API secret is required`);
 

--- a/packages/relay/src/relayer.ts
+++ b/packages/relay/src/relayer.ts
@@ -141,8 +141,8 @@ interface RelayerEIP1559Transaction extends RelayerTransactionBase {
 export type RelayerTransaction = RelayerLegacyTransaction | RelayerEIP1559Transaction;
 
 export type RelayerParams = ApiRelayerParams | AutotaskRelayerParams;
-export type ApiRelayerParams = { apiKey: string; apiSecret: string; httpAgent?: https.Agent };
-export type AutotaskRelayerParams = { credentials: string; relayerARN: string; httpAgent?: https.Agent };
+export type ApiRelayerParams = { apiKey: string; apiSecret: string; httpsAgent?: https.Agent };
+export type AutotaskRelayerParams = { credentials: string; relayerARN: string; httpsAgent?: https.Agent };
 
 export type JsonRpcResponse = {
   id: number | null;

--- a/packages/relay/src/relayer.ts
+++ b/packages/relay/src/relayer.ts
@@ -1,5 +1,6 @@
-import { ApiRelayer } from './api';
 import { Network } from 'defender-base-client';
+import https from 'https';
+import { ApiRelayer } from './api';
 export type Address = string;
 export type BigUInt = string | number;
 export type Hex = string;
@@ -140,8 +141,8 @@ interface RelayerEIP1559Transaction extends RelayerTransactionBase {
 export type RelayerTransaction = RelayerLegacyTransaction | RelayerEIP1559Transaction;
 
 export type RelayerParams = ApiRelayerParams | AutotaskRelayerParams;
-export type ApiRelayerParams = { apiKey: string; apiSecret: string };
-export type AutotaskRelayerParams = { credentials: string; relayerARN: string };
+export type ApiRelayerParams = { apiKey: string; apiSecret: string; httpAgent?: https.Agent };
+export type AutotaskRelayerParams = { credentials: string; relayerARN: string; httpAgent?: https.Agent };
 
 export type JsonRpcResponse = {
   id: number | null;


### PR DESCRIPTION
Simple changes to allow integration to pass over their own httpAgent which allows them to control the keep alive, timeouts, max free sockets, scheduling and all that jazz

simple change it imports https but that's purely typings and no bundle add minus the new property!