### PR TITLE
Only attempt to set `global.crypto` in non-browser context

### DIFF
--- a/packages/base/src/api/auth.ts
+++ b/packages/base/src/api/auth.ts
@@ -2,7 +2,9 @@
 
 // https://github.com/aws-amplify/amplify-js/issues/7098
 // fix for amazon-cognito-identity
-global.crypto = require('crypto');
+if (typeof window === 'undefined') {
+    global.crypto = require('crypto');
+}
 
 import { AuthenticationDetails, CognitoUserPool, CognitoUser } from 'amazon-cognito-identity-js';
 import retry from 'async-retry';


### PR DESCRIPTION
Do not attempt to overwrite `global.crypto` in a browser context. Attempting to set `global.crypto` in a browser context triggers an error:

```
TypeError: Cannot set property crypto of #<Object> which has only a getter
```

Per the [MDN docs][1], this `global.crypto` property is read-only and cannot be set.

While the Defender/Relay clients are intended to be used server-side only, there are some development environments, such as Next.js, that comingle the browser and server contexts. Even if you are not using the OpenZeppelin code in browser, before Next.js does code-splitting the package could be imported and cause the above `TypeError`.

If we just wrap the assignment to `global.crypto` in a browser-context check (`typeof window === 'undefined'`), then the Defender client can safely be used in Next.js and similar codebases.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/crypto_property