### PR TITLE
Filter autotask runs by status

### DIFF
--- a/packages/autotask-client/README.md
+++ b/packages/autotask-client/README.md
@@ -169,6 +169,12 @@ You can list all runs for an autotask with the following command:
 await client.listAutotaskRuns(autotaskId);
 ```
 
+List of all runs can be filtered by status:
+
+```js
+await client.listAutotaskRuns(autotaskId, 'error');
+```
+
 And get detailed logs for a single run using the `autotaskRunId` (returned in the `listAutotaskRuns` response directly above):
 
 ```js

--- a/packages/autotask-client/src/api.ts
+++ b/packages/autotask-client/src/api.ts
@@ -6,7 +6,12 @@ import {
   GetSecretsResponse,
   SaveSecretsRequest,
 } from './models/autotask';
-import { AutotaskRunBase, AutotaskRunListResponse, AutotaskRunResponse } from './models/autotask-run.res';
+import {
+  AutotaskRunBase,
+  AutotaskRunListResponse,
+  AutotaskRunResponse,
+  AutotaskRunStatus,
+} from './models/autotask-run.res';
 import { AutotaskDeleteResponse, AutotaskListResponse, AutotaskResponse } from './models/response';
 import { zipFolder, zipSources } from './zip';
 
@@ -85,9 +90,17 @@ export class AutotaskClient extends BaseApiClient {
     return this.updateCode(autotaskId, encodedZippedCode);
   }
 
-  public async listAutotaskRuns(autotaskId: string, next?: string): Promise<AutotaskRunListResponse> {
+  public async listAutotaskRuns(
+    autotaskId: string,
+    next?: string,
+    status?: AutotaskRunStatus | undefined,
+  ): Promise<AutotaskRunListResponse> {
+    if (next && !status && (next === 'success' || next === 'error' || next === 'pending' || next === 'throttle')) {
+      status = next as AutotaskRunStatus;
+      next = undefined;
+    }
     return this.apiCall(async (api) => {
-      return await api.get(`/autotasks/${autotaskId}/runs`, { params: { next } });
+      return api.get(`/autotasks/${autotaskId}/runs`, { params: { next, status } });
     });
   }
 


### PR DESCRIPTION
This PR will add support for filtering autotask runs by status.

See: https://github.com/OpenZeppelin/defender/pull/3476

