### PR TITLE
Deploy publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run `yarn lint` at the project root.
 
 ### Defender Client
 
-Use `lerna` for publishing a new version of all Defender Client packages. 
+Use `lerna` for publishing a new version of all Defender Client packages (excludes Platform Deploy Client as it is versioned separately). 
 
 The following publishes a release candidate with the npm tag `next`:
 
@@ -41,7 +41,17 @@ yarn run lerna publish --exact --force-publish
 
 ### Platform Deploy Client
 
+Change to the `packages/deploy` directory, login to npm, and publish using the native `yarn publish` command as shown below. We are not tagging versions for the time being as they conflict with previous Defender Client releases. Note this process is being introduced for the Platform Deploy Client v0 release, but will be migrated to a new Platform Client-specific repository.
 
+```
+npm login
+cd packages/deploy
+git checkout master
+git pull origin master
+yarn publish --no-git-tag-version
+# enter new version at prompt
+git push origin master
+```
 
 ## Examples
 

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-deploy-client",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Client library for managing Platform Deployments",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Note that in addition to the PR, there is a change on `master` to be aware of: `lerna.json` has been updated to exclude `deploy` package. This ensured that we would not need to change the existing deploy process for Defender Client Packages. I started trying to get Lerna to play nice with the Deploy package, but ultimately it looked like it was going to require some bigger configuration changes that didn't seem worth the time as we will migrate this package to a new repo soon.