### PR TITLE
Add logic to use refresh token for authentification for long running …

### DIFF
--- a/packages/base/src/api/api.ts
+++ b/packages/base/src/api/api.ts
@@ -1,6 +1,7 @@
 import { CognitoUserSession } from 'amazon-cognito-identity-js';
 import axios, { AxiosError, AxiosInstance } from 'axios';
 import https from 'https';
+
 import { DefenderApiResponseError } from './api-error';
 
 export function rejectWithDefenderApiError(axiosError: AxiosError): Promise<never> {
@@ -22,14 +23,13 @@ export function createApi(key: string, token: string, apiUrl: string, httpsAgent
   return instance;
 }
 
-export async function createAuthenticatedApi(
+export function createAuthenticatedApi(
   username: string,
   session: CognitoUserSession,
   apiUrl: string,
   httpsAgent?: https.Agent,
-): Promise<AxiosInstance> {
+): AxiosInstance {
   const accessToken = session.getAccessToken().getJwtToken();
-  const api = createApi(username, accessToken, apiUrl, httpsAgent);
 
-  return api;
+  return createApi(username, accessToken, apiUrl, httpsAgent);
 }

--- a/packages/base/src/api/api.ts
+++ b/packages/base/src/api/api.ts
@@ -1,7 +1,7 @@
+import { CognitoUserSession } from 'amazon-cognito-identity-js';
 import axios, { AxiosError, AxiosInstance } from 'axios';
 import https from 'https';
 import { DefenderApiResponseError } from './api-error';
-import { authenticate, PoolData, UserPass } from './auth';
 
 export function rejectWithDefenderApiError(axiosError: AxiosError): Promise<never> {
   return Promise.reject(new DefenderApiResponseError(axiosError));
@@ -23,12 +23,13 @@ export function createApi(key: string, token: string, apiUrl: string, httpsAgent
 }
 
 export async function createAuthenticatedApi(
-  userPass: UserPass,
-  poolData: PoolData,
+  username: string,
+  session: CognitoUserSession,
   apiUrl: string,
   httpsAgent?: https.Agent,
 ): Promise<AxiosInstance> {
-  const token = await authenticate(userPass, poolData);
-  const api = createApi(userPass.Username, token, apiUrl, httpsAgent);
+  const accessToken = session.getAccessToken().getJwtToken();
+  const api = createApi(username, accessToken, apiUrl, httpsAgent);
+
   return api;
 }

--- a/packages/base/src/api/auth.ts
+++ b/packages/base/src/api/auth.ts
@@ -1,6 +1,6 @@
 // Adapted from https://gist.githubusercontent.com/efimk-lu/b48fa118bd29a35fc1767fe749fa3372/raw/0662fee3eb5c65172fdf85c4bdfcb96eabce5e21/authentication-example.js
 
-import { AuthenticationDetails, CognitoUserPool, CognitoUser } from 'amazon-cognito-identity-js';
+import { AuthenticationDetails, CognitoUserPool, CognitoUser, CognitoUserSession } from 'amazon-cognito-identity-js';
 import retry from 'async-retry';
 
 // https://github.com/node-fetch/node-fetch/issues/450#issuecomment-387045223
@@ -13,29 +13,57 @@ global.fetch = require('node-fetch').default;
 export type UserPass = { Username: string; Password: string };
 export type PoolData = { UserPoolId: string; ClientId: string };
 
-export async function authenticate(authenticationData: UserPass, poolData: PoolData): Promise<string> {
+export async function authenticate(authenticationData: UserPass, poolData: PoolData): Promise<CognitoUserSession> {
   const authenticationDetails = new AuthenticationDetails(authenticationData);
   const userPool = new CognitoUserPool(poolData);
   const userData = { Username: authenticationData.Username, Pool: userPool };
   const cognitoUser = new CognitoUser(userData);
 
   try {
-    return await retry(() => doAuthenticate(cognitoUser, authenticationDetails), { retries: 3 });
+    return retry(() => doAuthenticate(cognitoUser, authenticationDetails), { retries: 3 });
   } catch (err) {
     throw new Error(`Failed to get a token for the API key ${authenticationData.Username}: ${err.message || err}`);
   }
 }
 
-function doAuthenticate(cognitoUser: CognitoUser, authenticationDetails: AuthenticationDetails): Promise<string> {
+function doAuthenticate(
+  cognitoUser: CognitoUser,
+  authenticationDetails: AuthenticationDetails,
+): Promise<CognitoUserSession> {
   return new Promise((resolve, reject) => {
     cognitoUser.authenticateUser(authenticationDetails, {
       onSuccess: function (session) {
-        const token = session.getAccessToken().getJwtToken();
-        resolve(token);
+        resolve(session);
       },
       onFailure: function (err) {
         reject(err);
       },
+    });
+  });
+}
+
+export async function refreshSession(
+  authenticationData: UserPass,
+  poolData: PoolData,
+  session: CognitoUserSession,
+): Promise<CognitoUserSession> {
+  const userPool = new CognitoUserPool(poolData);
+  const userData = { Username: authenticationData.Username, Pool: userPool };
+  const cognitoUser = new CognitoUser(userData);
+  try {
+    return retry(() => doRefreshSession(cognitoUser, session), { retries: 3 });
+  } catch (err) {
+    throw new Error(`Failed to refresh token for the API key ${authenticationData.Username}: ${err.message || err}`);
+  }
+}
+
+function doRefreshSession(cognitoUser: CognitoUser, session: CognitoUserSession): Promise<CognitoUserSession> {
+  return new Promise((resolve, reject) => {
+    cognitoUser.refreshSession(session.getRefreshToken(), function (error, session) {
+      if (error) {
+        return reject(error);
+      }
+      resolve(session);
     });
   });
 }

--- a/packages/base/src/api/client.ts
+++ b/packages/base/src/api/client.ts
@@ -1,11 +1,12 @@
 import { CognitoUserSession } from 'amazon-cognito-identity-js';
 import { AxiosInstance } from 'axios';
 import https from 'https';
+
 import { createAuthenticatedApi } from './api';
 import { authenticate, refreshSession } from './auth';
 
 export abstract class BaseApiClient {
-  private api: Promise<AxiosInstance> | undefined;
+  private api: AxiosInstance | undefined;
   private apiKey: string;
   private session: CognitoUserSession | undefined;
   private apiSecret: string;
@@ -22,7 +23,6 @@ export abstract class BaseApiClient {
     this.apiKey = params.apiKey;
     this.apiSecret = params.apiSecret;
     this.httpsAgent = params.httpsAgent;
-    this.session = undefined;
   }
 
   protected async init(): Promise<AxiosInstance> {


### PR DESCRIPTION
This PR will add refresh token logic support.

Previously we were always using standard auth to regenerate all tokens in case when access token expires.
With this change we would reuse available refresh token from first call to get new access token that can be used for future requests.

This change would be visible for users that use long running scripts as access token expiration is set to 1h.

Test steps:
- For some testing environment change access token duration to smaller value(Navigate to the Cognito api key pool)
- Modify some example script to execute two api calls with some timeout in between that is higher than access token validity. 
- Verify that it works
- Smoke test for all defender client packages to verify something is not broken
- Revert testing environment Cognito change