### PR TITLE
Bump deploy package dependency version

### DIFF
--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.6.3",
     "axios": "^0.21.2",
-    "defender-base-client": "1.38.0-rc.2",
+    "defender-base-client": "1.39.0",
     "lodash": "^4.17.19",
     "node-fetch": "^2.6.0"
   },


### PR DESCRIPTION
This PR bumps the dependency version for `defender-base-client` to `1.39.0`