### PR TITLE
Change block explorer api key update payload type

### DIFF
--- a/packages/deploy/README.md
+++ b/packages/deploy/README.md
@@ -135,6 +135,5 @@ And updating the Api Key for a given network
 const apiKeyId = '8181d9e0-88ce-4db0-802a-2b56e2e6a7b1';
 await client.BlockExplorerApiKey.update(apiKeyId, {
   key: 'LDNWOWFNEJ2WEL4WLKNWEF8F2MNWKEF',
-  network: 'goerli',
 });
 ```

--- a/packages/deploy/src/api/block-explorer-api-key.test.ts
+++ b/packages/deploy/src/api/block-explorer-api-key.test.ts
@@ -1,5 +1,5 @@
 import { BlockExplorerApiKeyClient } from './block-explorer-api-key';
-import { CreateBlockExplorerApiKeyRequest } from '../models';
+import { CreateBlockExplorerApiKeyRequest, UpdateBlockExplorerApiKeyRequest } from '../models';
 import { TestClient } from '../utils/index';
 
 jest.mock('defender-base-client');
@@ -15,6 +15,9 @@ describe('Block Explorer Api Key Client', () => {
   const createPaylod: CreateBlockExplorerApiKeyRequest = {
     key: 'random-key',
     network: 'goerli',
+  };
+  const updatePaylod: UpdateBlockExplorerApiKeyRequest = {
+    key: 'random-key',
   };
   beforeEach(() => {
     blockExplorerClient = new BlockExplorerApiKeyClient({
@@ -82,8 +85,8 @@ describe('Block Explorer Api Key Client', () => {
   });
   describe('update', () => {
     it('calls API correctly', async () => {
-      await blockExplorerClient.update('api-key-id', createPaylod);
-      expect(blockExplorerClient.api.put).toBeCalledWith('/block-explorer-api-key/api-key-id', createPaylod);
+      await blockExplorerClient.update('api-key-id', updatePaylod);
+      expect(blockExplorerClient.api.put).toBeCalledWith('/block-explorer-api-key/api-key-id', updatePaylod);
       expect(createAuthenticatedApi).toBeCalled();
     });
   });

--- a/packages/deploy/src/api/block-explorer-api-key.ts
+++ b/packages/deploy/src/api/block-explorer-api-key.ts
@@ -1,5 +1,10 @@
 import { PlatformApiClient } from './platform';
-import { BlockExplorerApiKeyResponse, CreateBlockExplorerApiKeyRequest, RemoveResponse } from '../models';
+import {
+  BlockExplorerApiKeyResponse,
+  CreateBlockExplorerApiKeyRequest,
+  RemoveResponse,
+  UpdateBlockExplorerApiKeyRequest,
+} from '../models';
 
 const PATH = '/block-explorer-api-key';
 
@@ -23,7 +28,7 @@ export class BlockExplorerApiKeyClient extends PlatformApiClient {
 
   public async update(
     blockExplorerApiKeyId: string,
-    payload: CreateBlockExplorerApiKeyRequest,
+    payload: UpdateBlockExplorerApiKeyRequest,
   ): Promise<BlockExplorerApiKeyResponse> {
     return this.apiCall(async (api) => {
       return api.put(`${PATH}/${blockExplorerApiKeyId}`, payload);

--- a/packages/deploy/src/models/index.ts
+++ b/packages/deploy/src/models/index.ts
@@ -84,6 +84,10 @@ export interface CreateBlockExplorerApiKeyRequest {
   stackResourceId?: string;
 }
 
+export interface UpdateBlockExplorerApiKeyRequest {
+  key: string;
+  stackResourceId?: string;
+}
 export interface BlockExplorerApiKeyResponse {
   blockExplorerApiKeyId: string;
   createdAt: string;


### PR DESCRIPTION
This PR removes the network field from the block explorer api key `update` method payload