### PR TITLE
Bump defender-base-client version for deploy package

### DIFF
--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.6.3",
     "axios": "^0.21.2",
-    "defender-base-client": "1.39.0",
+    "defender-base-client": "^1.40.0",
     "lodash": "^4.17.19",
     "node-fetch": "^2.6.0"
   },


### PR DESCRIPTION
Bumps the defender-base-client version for the deploy package to avoid conflicts with new networks added (arbitrum-nova). Currently causes a [conflict](https://github.com/OpenZeppelin/defender-serverless/actions/runs/4582757877/jobs/8093205850) for defender-serverless package.