### PR TITLE
Export UpgradeClient in deploy package

### DIFF
--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -2,6 +2,7 @@ export { PlatformClient } from './api';
 export { BlockExplorerApiKeyClient } from './api/block-explorer-api-key';
 export { DeploymentClient } from './api/deployment';
 export { DeploymentConfigClient } from './api/deployment-config';
+export { UpgradeClient } from './api/upgrade';
 export * from './models';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
The UpgradeClient API should be exported for easier access when using the deploy package.