### PR TITLE
fix: add base goerli to valid list

### DIFF
--- a/packages/base/src/utils/network.ts
+++ b/packages/base/src/utils/network.ts
@@ -74,6 +74,7 @@ export const Networks: Network[] = [
   'zksync-goerli',
   'x-dfk-avax-chain',
   'x-dfk-avax-chain-test',
+  'base-goerli',
 ];
 
 export function isValidNetwork(text: string): text is Network {


### PR DESCRIPTION
Hey everyone!

We realized that base goerli was added to the `PublicNetwork` type, but it wasn't added to the `Networks` list. So `isValidNetwork` would fail