### PR TITLE
remove git+ from repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/OpenZeppelin/defender-client.git"
+    "url": "https://github.com/OpenZeppelin/defender-client.git"
   },
   "author": "OpenZeppelin Defender <defender@openzeppelin.com>",
   "license": "MIT",


### PR DESCRIPTION
attempting to get npm to link directly to github repo (theory is `git+` broke their logic)