### PR TITLE
Expose network list endpoint

### DIFF
--- a/examples/list-networks/index.js
+++ b/examples/list-networks/index.js
@@ -1,0 +1,14 @@
+require('dotenv').config();
+
+const { SentinelClient } = require('@openzeppelin/defender-sentinel-client');
+
+async function main() {
+  const creds = { apiKey: process.env.ADMIN_API_KEY, apiSecret: process.env.ADMIN_API_SECRET };
+  const client = new SentinelClient(creds);
+  const networks = await client.listNetworks('prod');
+  console.log(networks);
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/examples/list-networks/index.js
+++ b/examples/list-networks/index.js
@@ -5,7 +5,7 @@ const { SentinelClient } = require('@openzeppelin/defender-sentinel-client');
 async function main() {
   const creds = { apiKey: process.env.ADMIN_API_KEY, apiSecret: process.env.ADMIN_API_SECRET };
   const client = new SentinelClient(creds);
-  const networks = await client.listNetworks('prod');
+  const networks = await client.listNetworks('production');
   console.log(networks);
 }
 

--- a/examples/list-networks/index.js
+++ b/examples/list-networks/index.js
@@ -5,7 +5,7 @@ const { SentinelClient } = require('@openzeppelin/defender-sentinel-client');
 async function main() {
   const creds = { apiKey: process.env.ADMIN_API_KEY, apiSecret: process.env.ADMIN_API_SECRET };
   const client = new SentinelClient(creds);
-  const networks = await client.listNetworks('production');
+  const networks = await client.listNetworks({ networkType: 'production' });
   console.log(networks);
 }
 

--- a/examples/list-networks/package.json
+++ b/examples/list-networks/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "list-networks",
+  "version": "1.47.0",
+  "private": true,
+  "main": "index.js",
+  "author": "Nami Shah <nami@openzeppelin.com>",
+  "license": "MIT",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@openzeppelin/defender-sentinel-client": "1.47.0",
+    "dotenv": "^8.2.0"
+  }
+}

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -379,7 +379,7 @@ To list tenant enabled networks, you can call the `listNetworks` function on the
 
 ```js
 await client.listNetworks(); // lists all networks
-await client.listNetworks('prod'); // lists only production networks
+await client.listNetworks('production'); // lists only production networks
 await client.listNetworks('test'); // lists only test networks
 ```
 

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -373,6 +373,16 @@ await client.pause('8181d9e0-88ce-4db0-802a-2b56e2e6a7b1');
 await client.unpause('8181d9e0-88ce-4db0-802a-2b56e2e6a7b1');
 ```
 
+### List Networks
+
+To list tenant enabled networks, you can call the `listNetworks` function on the client, which returns a `Network[]` object:
+
+```js
+await client.listNetworks(); // lists all networks
+await client.listNetworks('prod'); // lists only production networks
+await client.listNetworks('test'); // lists only test networks
+```
+
 ### Failed Requests
 
 Failed requests might return the following example response object:

--- a/packages/sentinel/README.md
+++ b/packages/sentinel/README.md
@@ -379,8 +379,8 @@ To list tenant enabled networks, you can call the `listNetworks` function on the
 
 ```js
 await client.listNetworks(); // lists all networks
-await client.listNetworks('production'); // lists only production networks
-await client.listNetworks('test'); // lists only test networks
+await client.listNetworks({ networkType: 'production' }); // lists only production networks
+await client.listNetworks({ networkType: 'test' }); // lists only test networks
 ```
 
 ### Failed Requests

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -28,7 +28,7 @@ import {
   NotificationCategory as NotificationCategoryResponse,
   UpdateNotificationCategoryRequest,
 } from '../models/category';
-import { NetworkType } from '../models/networks';
+import { ListNetworkRequestOptions } from '../models/networks';
 
 export class SentinelClient extends BaseApiClient {
   protected getPoolId(): string {
@@ -43,9 +43,9 @@ export class SentinelClient extends BaseApiClient {
     return process.env.DEFENDER_SENTINEL_API_URL || 'https://defender-api.openzeppelin.com/sentinel/';
   }
 
-  public async listNetworks(type?: NetworkType): Promise<Network[]> {
+  public async listNetworks(opts?: ListNetworkRequestOptions): Promise<Network[]> {
     return this.apiCall(async (api) => {
-      return await api.get(type ? `/networks?type=${type}` : `/networks`);
+      return await api.get(opts && opts.networkType ? `/networks?type=${opts.networkType}` : `/networks`);
     });
   }
 

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -28,6 +28,7 @@ import {
   NotificationCategory as NotificationCategoryResponse,
   UpdateNotificationCategoryRequest,
 } from '../models/category';
+import { NetworkType } from '../models/networks';
 
 export class SentinelClient extends BaseApiClient {
   protected getPoolId(): string {
@@ -40,6 +41,12 @@ export class SentinelClient extends BaseApiClient {
 
   protected getApiUrl(): string {
     return process.env.DEFENDER_SENTINEL_API_URL || 'https://defender-api.openzeppelin.com/sentinel/';
+  }
+
+  public async listNetworks(type?: NetworkType): Promise<Network[]> {
+    return this.apiCall(async (api) => {
+      return await api.get(type ? `/networks?type=${type}` : `/networks`);
+    });
   }
 
   public async list(): Promise<ListSentinelResponse> {

--- a/packages/sentinel/src/models/networks.ts
+++ b/packages/sentinel/src/models/networks.ts
@@ -1,1 +1,5 @@
 export type NetworkType = 'production' | 'test';
+
+export interface ListNetworkRequestOptions {
+  networkType?: NetworkType;
+}

--- a/packages/sentinel/src/models/networks.ts
+++ b/packages/sentinel/src/models/networks.ts
@@ -1,1 +1,1 @@
-export type NetworkType = 'prod' | 'test';
+export type NetworkType = 'production' | 'test';

--- a/packages/sentinel/src/models/networks.ts
+++ b/packages/sentinel/src/models/networks.ts
@@ -1,0 +1,1 @@
+export type NetworkType = 'prod' | 'test';


### PR DESCRIPTION
Add a `listNetworks` function to the sentinel package

I've added the endpoint to sentinel package to stay consistent with where it is hosted in `platform-sdk` (in monitor).