### PR TITLE
Support api versioning 

### DIFF
--- a/examples/batch-proposal/index.js
+++ b/examples/batch-proposal/index.js
@@ -59,7 +59,7 @@ const steps = [
 ];
 
 async function main() {
-  const { url } = await client.createProposal({
+  const { url, contractId, proposalId } = await client.createProposal({
     contract: contracts,
     title: 'Batch test',
     description: 'Mint, transfer and modify access control',
@@ -71,6 +71,12 @@ async function main() {
   });
 
   console.log(url);
+
+  // archive/unarchive
+  const archived = await client.archiveProposal(contractId, proposalId);
+  console.log('proposal archived', archived.isArchived);
+  const unarchived = await client.unarchiveProposal(contractId, proposalId);
+  console.log('proposal archived', unarchived.isArchived);
 }
 
 if (require.main === module) {

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -1,4 +1,4 @@
-import { BaseApiClient } from '@openzeppelin/defender-base-client';
+import { BaseApiClient, ApiVersion } from '@openzeppelin/defender-base-client';
 import { capitalize, isArray, isEmpty } from 'lodash';
 import { Interface } from 'ethers/lib/utils';
 
@@ -54,7 +54,10 @@ export class AdminClient extends BaseApiClient {
     return process.env.DEFENDER_ADMIN_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(): string {
+  protected getApiUrl(v: ApiVersion): string {
+    if (v === 'v2') {
+      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    }
     return process.env.DEFENDER_ADMIN_API_URL || 'https://defender-api.openzeppelin.com/admin/';
   }
 
@@ -160,22 +163,18 @@ export class AdminClient extends BaseApiClient {
     });
   }
 
-  public async archiveProposal(contractId: string, proposalId: string): Promise<ProposalResponseWithUrl> {
+  public async archiveProposal(_: string, proposalId: string): Promise<ProposalResponseWithUrl> {
     return this.apiCall(async (api) => {
-      const response = (await api.put(`/contracts/${contractId}/proposals/${proposalId}/archived`, {
-        archived: true,
-      })) as ProposalResponse;
+      const response = (await api.put(`proposals/archive/${proposalId}`)) as ProposalResponse;
       return { ...response, url: getProposalUrl(response) };
-    });
+    }, 'v2');
   }
 
-  public async unarchiveProposal(contractId: string, proposalId: string): Promise<ProposalResponseWithUrl> {
+  public async unarchiveProposal(_: string, proposalId: string): Promise<ProposalResponseWithUrl> {
     return this.apiCall(async (api) => {
-      const response = (await api.put(`/contracts/${contractId}/proposals/${proposalId}/archived`, {
-        archived: false,
-      })) as ProposalResponse;
+      const response = (await api.put(`proposals/unarchive/${proposalId}`)) as ProposalResponse;
       return { ...response, url: getProposalUrl(response) };
-    });
+    }, 'v2');
   }
 
   public async getProposalSimulation(contractId: string, proposalId: string): Promise<SimulationResponse> {

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -54,7 +54,7 @@ export class AdminClient extends BaseApiClient {
     return process.env.DEFENDER_ADMIN_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(v: ApiVersion): string {
+  protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
       return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -56,7 +56,7 @@ export class AdminClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_V2_URL || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.DEFENDER_ADMIN_API_URL || 'https://defender-api.openzeppelin.com/admin/';
   }

--- a/packages/admin/src/api.ts
+++ b/packages/admin/src/api.ts
@@ -56,7 +56,7 @@ export class AdminClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.DEFENDER_ADMIN_API_URL || 'https://defender-api.openzeppelin.com/admin/';
   }

--- a/packages/autotask-client/src/api.ts
+++ b/packages/autotask-client/src/api.ts
@@ -29,7 +29,7 @@ export class AutotaskClient extends BaseApiClient {
     return process.env.DEFENDER_AUTOTASK_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(v: ApiVersion): string {
+  protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
       return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }

--- a/packages/autotask-client/src/api.ts
+++ b/packages/autotask-client/src/api.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { BaseApiClient } from '@openzeppelin/defender-base-client';
+import { BaseApiClient, ApiVersion } from '@openzeppelin/defender-base-client';
 import {
   CreateAutotaskRequest,
   UpdateAutotaskRequest,
@@ -29,7 +29,10 @@ export class AutotaskClient extends BaseApiClient {
     return process.env.DEFENDER_AUTOTASK_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(): string {
+  protected getApiUrl(v: ApiVersion): string {
+    if (v === 'v2') {
+      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    }
     return process.env.DEFENDER_AUTOTASK_API_URL || 'https://defender-api.openzeppelin.com/autotask/';
   }
 

--- a/packages/autotask-client/src/api.ts
+++ b/packages/autotask-client/src/api.ts
@@ -31,7 +31,7 @@ export class AutotaskClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.DEFENDER_AUTOTASK_API_URL || 'https://defender-api.openzeppelin.com/autotask/';
   }

--- a/packages/autotask-client/src/api.ts
+++ b/packages/autotask-client/src/api.ts
@@ -31,7 +31,7 @@ export class AutotaskClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_V2_URL || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.DEFENDER_AUTOTASK_API_URL || 'https://defender-api.openzeppelin.com/autotask/';
   }

--- a/packages/base/src/api/client.ts
+++ b/packages/base/src/api/client.ts
@@ -28,7 +28,7 @@ export abstract class BaseApiClient {
     this.httpsAgent = params.httpsAgent;
   }
 
-  protected async init(v: ApiVersion): Promise<AxiosInstance> {
+  protected async init(v: ApiVersion = 'v1'): Promise<AxiosInstance> {
     if (!this.api || this.version !== v) {
       const userPass = { Username: this.apiKey, Password: this.apiSecret };
       const poolData = { UserPoolId: this.getPoolId(), ClientId: this.getPoolClientId() };
@@ -39,7 +39,7 @@ export abstract class BaseApiClient {
     return this.api;
   }
 
-  protected async refresh(v: ApiVersion): Promise<AxiosInstance> {
+  protected async refresh(v: ApiVersion = 'v1'): Promise<AxiosInstance> {
     if (!this.session) {
       return this.init(v);
     }

--- a/packages/base/src/api/client.ts
+++ b/packages/base/src/api/client.ts
@@ -5,8 +5,11 @@ import https from 'https';
 import { createAuthenticatedApi } from './api';
 import { authenticate, refreshSession } from './auth';
 
+export type ApiVersion = 'v1' | 'v2';
+
 export abstract class BaseApiClient {
   private api: AxiosInstance | undefined;
+  private version: ApiVersion | undefined;
   private apiKey: string;
   private session: CognitoUserSession | undefined;
   private apiSecret: string;
@@ -14,7 +17,7 @@ export abstract class BaseApiClient {
 
   protected abstract getPoolId(): string;
   protected abstract getPoolClientId(): string;
-  protected abstract getApiUrl(): string;
+  protected abstract getApiUrl(v: ApiVersion): string;
 
   public constructor(params: { apiKey: string; apiSecret: string; httpsAgent?: https.Agent }) {
     if (!params.apiKey) throw new Error(`API key is required`);
@@ -25,34 +28,35 @@ export abstract class BaseApiClient {
     this.httpsAgent = params.httpsAgent;
   }
 
-  protected async init(): Promise<AxiosInstance> {
-    if (!this.api) {
+  protected async init(v: ApiVersion): Promise<AxiosInstance> {
+    if (!this.api || this.version !== v) {
       const userPass = { Username: this.apiKey, Password: this.apiSecret };
       const poolData = { UserPoolId: this.getPoolId(), ClientId: this.getPoolClientId() };
       this.session = await authenticate(userPass, poolData);
-      this.api = createAuthenticatedApi(userPass.Username, this.session, this.getApiUrl(), this.httpsAgent);
+      this.api = createAuthenticatedApi(userPass.Username, this.session, this.getApiUrl(v), this.httpsAgent);
+      this.version = v;
     }
     return this.api;
   }
 
-  protected async refresh(): Promise<AxiosInstance> {
+  protected async refresh(v: ApiVersion): Promise<AxiosInstance> {
     if (!this.session) {
-      return this.init();
+      return this.init(v);
     }
     try {
       const userPass = { Username: this.apiKey, Password: this.apiSecret };
       const poolData = { UserPoolId: this.getPoolId(), ClientId: this.getPoolClientId() };
       this.session = await refreshSession(userPass, poolData, this.session);
-      this.api = createAuthenticatedApi(userPass.Username, this.session, this.getApiUrl(), this.httpsAgent);
+      this.api = createAuthenticatedApi(userPass.Username, this.session, this.getApiUrl(v), this.httpsAgent);
 
       return this.api;
     } catch (e) {
-      return this.init();
+      return this.init(v);
     }
   }
 
-  protected async apiCall<T>(fn: (api: AxiosInstance) => Promise<T>): Promise<T> {
-    const api = await this.init();
+  protected async apiCall<T>(fn: (api: AxiosInstance) => Promise<T>, v: ApiVersion = 'v1'): Promise<T> {
+    const api = await this.init(v);
     try {
       return await fn(api);
     } catch (error: any) {
@@ -60,7 +64,7 @@ export abstract class BaseApiClient {
       if (error.response && error.response.status === 401 && error.response.statusText === 'Unauthorized') {
         this.api = undefined;
 
-        const api = await this.refresh();
+        const api = await this.refresh(v);
         return await fn(api);
       }
       throw error;

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -1,6 +1,6 @@
 export { createApi, createAuthenticatedApi } from './api/api';
 export { authenticate } from './api/auth';
-export { BaseApiClient } from './api/client';
+export { BaseApiClient, ApiVersion } from './api/client';
 export * from './utils/network';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/deploy/src/api/platform.ts
+++ b/packages/deploy/src/api/platform.ts
@@ -9,7 +9,7 @@ export class PlatformApiClient extends BaseApiClient {
     return process.env.PLATFORM_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(v: ApiVersion): string {
+  protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
       return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }

--- a/packages/deploy/src/api/platform.ts
+++ b/packages/deploy/src/api/platform.ts
@@ -1,4 +1,4 @@
-import { BaseApiClient } from '@openzeppelin/defender-base-client';
+import { BaseApiClient, ApiVersion } from '@openzeppelin/defender-base-client';
 
 export class PlatformApiClient extends BaseApiClient {
   protected getPoolId(): string {
@@ -9,7 +9,10 @@ export class PlatformApiClient extends BaseApiClient {
     return process.env.PLATFORM_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(): string {
+  protected getApiUrl(v: ApiVersion): string {
+    if (v === 'v2') {
+      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    }
     return process.env.PLATFORM_API_URL || 'https://defender-api.openzeppelin.com/deployment/';
   }
 }

--- a/packages/deploy/src/api/platform.ts
+++ b/packages/deploy/src/api/platform.ts
@@ -11,7 +11,7 @@ export class PlatformApiClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.PLATFORM_API_URL || 'https://defender-api.openzeppelin.com/deployment/';
   }

--- a/packages/deploy/src/api/platform.ts
+++ b/packages/deploy/src/api/platform.ts
@@ -11,7 +11,7 @@ export class PlatformApiClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_V2_URL || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.PLATFORM_API_URL || 'https://defender-api.openzeppelin.com/deployment/';
   }

--- a/packages/relay/src/api/index.ts
+++ b/packages/relay/src/api/index.ts
@@ -1,4 +1,4 @@
-import { BaseApiClient } from '@openzeppelin/defender-base-client';
+import { BaseApiClient, ApiVersion } from '@openzeppelin/defender-base-client';
 import {
   ApiRelayerParams,
   IRelayer,
@@ -30,7 +30,10 @@ export class RelayClient extends BaseApiClient {
     return process.env.DEFENDER_RELAY_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(): string {
+  protected getApiUrl(v: ApiVersion): string {
+    if (v === 'v2') {
+      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    }
     return process.env.DEFENDER_RELAY_API_URL || 'https://defender-api.openzeppelin.com/relayer/';
   }
 
@@ -116,7 +119,7 @@ export class ApiRelayer extends BaseApiClient implements IRelayer {
     return process.env.DEFENDER_RELAY_SIGNER_POOL_CLIENT_ID || '1bpd19lcr33qvg5cr3oi79rdap';
   }
 
-  protected getApiUrl(): string {
+  protected getApiUrl(_: ApiVersion): string {
     return RelaySignerApiUrl();
   }
 

--- a/packages/relay/src/api/index.ts
+++ b/packages/relay/src/api/index.ts
@@ -32,7 +32,7 @@ export class RelayClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_V2_URL || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.DEFENDER_RELAY_API_URL || 'https://defender-api.openzeppelin.com/relayer/';
   }

--- a/packages/relay/src/api/index.ts
+++ b/packages/relay/src/api/index.ts
@@ -32,7 +32,7 @@ export class RelayClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.DEFENDER_RELAY_API_URL || 'https://defender-api.openzeppelin.com/relayer/';
   }

--- a/packages/relay/src/api/index.ts
+++ b/packages/relay/src/api/index.ts
@@ -30,7 +30,7 @@ export class RelayClient extends BaseApiClient {
     return process.env.DEFENDER_RELAY_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(v: ApiVersion): string {
+  protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
       return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -1,4 +1,4 @@
-import { BaseApiClient, Network } from '@openzeppelin/defender-base-client';
+import { BaseApiClient, Network, ApiVersion } from '@openzeppelin/defender-base-client';
 import {
   ConditionSet,
   CreateSubscriberRequest,
@@ -39,7 +39,10 @@ export class SentinelClient extends BaseApiClient {
     return process.env.DEFENDER_SENTINEL_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(): string {
+  protected getApiUrl(v: ApiVersion): string {
+    if (v === 'v2') {
+      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+    }
     return process.env.DEFENDER_SENTINEL_API_URL || 'https://defender-api.openzeppelin.com/sentinel/';
   }
 

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -41,7 +41,7 @@ export class SentinelClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_V2_URL || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.DEFENDER_SENTINEL_API_URL || 'https://defender-api.openzeppelin.com/sentinel/';
   }

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -39,7 +39,7 @@ export class SentinelClient extends BaseApiClient {
     return process.env.DEFENDER_SENTINEL_POOL_CLIENT_ID || '40e58hbc7pktmnp9i26hh5nsav';
   }
 
-  protected getApiUrl(v: ApiVersion): string {
+  protected getApiUrl(v: ApiVersion = 'v1'): string {
     if (v === 'v2') {
       return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }

--- a/packages/sentinel/src/api/index.ts
+++ b/packages/sentinel/src/api/index.ts
@@ -41,7 +41,7 @@ export class SentinelClient extends BaseApiClient {
 
   protected getApiUrl(v: ApiVersion): string {
     if (v === 'v2') {
-      return process.env.DEFENDER_API_URL || 'https://defender-api.openzeppelin.com/v2/';
+      return process.env.DEFENDER_API_URL_V2 || 'https://defender-api.openzeppelin.com/v2/';
     }
     return process.env.DEFENDER_SENTINEL_API_URL || 'https://defender-api.openzeppelin.com/sentinel/';
   }


### PR DESCRIPTION
This PR allows to call defender 2.0 endpoints  from defender-client.
https://linear.app/openzeppelin-development/issue/PLAT-1665/no-way-to-archive-batch-proposals-with-multiple-contracts

Usage:

```js
  public async someFunction(id: string): Promise<Response> {
    return this.apiCall(async (api) => {
      return await api.put(`suffix/${id}`);
    }, 'v2'); // <- here we specify the version
  });
```


```js
  public async someFunction(id: string): Promise<Response> {
    return this.apiCall(async (api) => {
      return await api.put(`suffix/${id}`);
    }); // <- defaults to 'v1'
  });
```