### PR TITLE
[Fixes Issue #325] Update types for ProposalFunctionInputs to match API documentation

### DIFF
--- a/packages/admin/src/models/proposal.ts
+++ b/packages/admin/src/models/proposal.ts
@@ -7,7 +7,12 @@ export type BigUInt = string | number;
 export type ProposalType = ProposalStepType | ProposalBatchType;
 export type ProposalStepType = 'upgrade' | 'custom' | 'pause' | 'send-funds' | 'access-control';
 export type ProposalBatchType = 'batch';
-export type ProposalFunctionInputs = (string | boolean | (string | boolean)[])[];
+type ProposalFunctionInputsArray = (string | boolean)[];
+type ProposalFunctionInputs = (
+  | string
+  | boolean
+  | (string | boolean | (string | boolean | (string | boolean | ProposalFunctionInputsArray)[])[])[]
+)[];
 
 export interface ExternalApiCreateProposalRequest {
   contract: PartialContract | PartialContract[];


### PR DESCRIPTION
See documentation in https://docs.openzeppelin.com/defender/v1/admin-api-reference

```
type ProposalFunctionInputsArray = (string | boolean)[];
type ProposalFunctionInputs = (
  | string
  | boolean
  | (string | boolean | (string | boolean | (string | boolean | ProposalFunctionInputsArray)[])[])[]
)[];
```