### PR TITLE
Add support for relayer status endpoint

### DIFF
--- a/examples/relayer-actions/index.js
+++ b/examples/relayer-actions/index.js
@@ -10,6 +10,11 @@ async function get() {
   console.log('relayerInfo', JSON.stringify(info, null, 2));
 }
 
+async function status() {
+  const info = await relayer.getRelayerStatus();
+  console.log('relayerStatus', JSON.stringify(info, null, 2));
+}
+
 async function send() {
   const txResponse = await relayer.sendTransaction({
     to: '0x179810822f56b0e79469189741a3fa5f2f9a7631',
@@ -64,7 +69,7 @@ async function jsonrpc(method, payload) {
   try {
     const action = process.argv[2];
     if (!action) {
-      console.error(`Usage: node index.js query|get|send|sign|balance`);
+      console.error(`Usage: node index.js query|get|status|send|sign|balance`);
       process.exit(1);
     }
     console.log(`Using client version`, VERSION);
@@ -73,6 +78,8 @@ async function jsonrpc(method, payload) {
         return await query(process.argv[3]);
       case 'get':
         return await get();
+      case 'status':
+        return await status();
       case 'send':
         return await send();
       case 'replace':

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -173,7 +173,6 @@ const latestTx = await relayer.query(tx.transactionId);
 
 Alternatively, the `relayer` can also be used to `list` the latest transactions sent, optionally filtering by status and creation time.
 
-
 ```js
 const since = await relayer.list({
   since: new Date(Date.now() - 60 * 1000),
@@ -191,7 +190,7 @@ const since = await relayer.list({
   limit: 5,
   usePagination: true,
   sort: 'desc', // available only in combination with pagination
-  next: '' // optional: include when the response has this value to fetch the next set of results
+  next: '', // optional: include when the response has this value to fetch the next set of results
 });
 ```
 
@@ -212,7 +211,43 @@ The `query` function is important to monitor the transaction status, since Defen
 
 Defender may replace a transaction by increasing its gas price if it has not been mined for a period of time, and the gas price costs have increased since the transaction was originally submitted. Also, in a case where a transaction consistently fails to be mined, Defender may replace it by a _no-op_ (a transaction with no value or data) in order to advance the sender account nonce.
 
-#### Replacing transactions
+### Relayer Status
+
+To gain better insight into the current status of a relayer, you can use the `getRelayerStatus` method. This method provides real-time information about a relayer, such as its nonce, transaction quota, and the number of pending transactions.
+
+To get the current status of a relayer:
+
+```js
+const status = await relayer.getRelayerStatus('58b3d255-e357-4b0d-aa16-e86f745e63b9');
+```
+
+The response will be of the shape:
+
+```js
+export interface RelayerStatus {
+  relayerId: string; // Unique identifier for the relayer
+  name: string; // Name of the relayer
+  nonce: number; // Current relayer nonce
+  address: string; // Address of the relayer
+  numberOfPendingTransactions: number; // Number of transactions: pending|sent|submitted|inmempool
+  paused: boolean; // If the relayer is paused or not
+  pendingTxCost?: string; // The total cost of all pending transactions, if available
+  txsQuotaUsage: number; // Used transaction quota for the relayer
+  rpcQuotaUsage: number; // Used RPC quota for the relayer
+  lastConfirmedTransaction?: {
+    // Details of the last confirmed transaction
+    hash: string,
+    status: string,
+    minedAt: string,
+    sentAt: string,
+    nonce: number,
+  };
+}
+```
+
+This method can be particularly helpful in monitoring and managing your relayer resources more effectively.
+
+### Replacing transactions
 
 You can use the relayer methods `replaceTransactionById` or `replaceTransactionByNonce` to replace a transaction given its nonce or transactionId (not hash) if it has not been mined yet. You can use this to increase the speed of a transaction, or replace your tx by an empty value transfer (with a gas limit of 21000) to cancel a transaction that is no longer valid.
 

--- a/packages/relay/src/api/index.ts
+++ b/packages/relay/src/api/index.ts
@@ -17,6 +17,7 @@ import {
   RelayerApiKey,
   DeleteRelayerApiKeyResponse,
   PaginatedTransactionListResponse,
+  RelayerStatus,
 } from '../relayer';
 
 export const RelaySignerApiUrl = () =>
@@ -127,6 +128,12 @@ export class ApiRelayer extends BaseApiClient implements IRelayer {
   public async getRelayer(): Promise<RelayerGetResponse> {
     return this.apiCall(async (api) => {
       return (await api.get('/relayer')) as RelayerGetResponse;
+    });
+  }
+
+  public async getRelayerStatus(): Promise<RelayerStatus> {
+    return this.apiCall(async (api) => {
+      return (await api.get('/relayer/status')) as RelayerStatus;
     });
   }
 

--- a/packages/relay/src/autotask/index.test.ts
+++ b/packages/relay/src/autotask/index.test.ts
@@ -102,6 +102,17 @@ describe('AutotaskRelayer', () => {
     });
   });
 
+  describe('getRelayerStatus', () => {
+    test('passes correct arguments to the API', async () => {
+      await relayer.getRelayerStatus();
+      expect(relayer.lambda.invoke).toBeCalledWith({
+        FunctionName: 'arn',
+        InvocationType: 'RequestResponse',
+        Payload: '{"action":"get-self-status"}',
+      });
+    });
+  });
+
   describe('sign', () => {
     test('passes correct arguments to the API', async () => {
       await relayer.sign({ message: 'test' });

--- a/packages/relay/src/autotask/index.ts
+++ b/packages/relay/src/autotask/index.ts
@@ -5,6 +5,7 @@ import {
   JsonRpcResponse,
   ListTransactionsRequest,
   RelayerGetResponse,
+  RelayerStatus,
   RelayerTransaction,
   RelayerTransactionPayload,
   SignedMessagePayload,
@@ -71,6 +72,12 @@ export class AutotaskRelayer extends BaseAutotaskClient implements IRelayer {
   public async getRelayer(): Promise<RelayerGetResponse> {
     return this.execute({
       action: 'get-self' as const,
+    });
+  }
+
+  public async getRelayerStatus(): Promise<RelayerStatus> {
+    return this.execute({
+      action: 'get-self-status' as const,
     });
   }
 

--- a/packages/relay/src/relayer.ts
+++ b/packages/relay/src/relayer.ts
@@ -221,8 +221,28 @@ export type ListTransactionsRequest = {
   usePagination?: boolean;
 };
 
+export interface RelayerStatus {
+  relayerId: string;
+  name: string;
+  nonce: number;
+  address: string;
+  numberOfPendingTransactions: number;
+  paused: boolean;
+  pendingTxCost?: string;
+  txsQuotaUsage: number;
+  rpcQuotaUsage: number;
+  lastConfirmedTransaction?: {
+    hash: string;
+    status: string;
+    minedAt: string;
+    sentAt: string;
+    nonce: number;
+  };
+}
+
 export interface IRelayer {
   getRelayer(): Promise<RelayerGetResponse>;
+  getRelayerStatus(): Promise<RelayerStatus>;
   sendTransaction(payload: RelayerTransactionPayload): Promise<RelayerTransaction>;
   replaceTransactionById(id: string, payload: RelayerTransactionPayload): Promise<RelayerTransaction>;
   replaceTransactionByNonce(nonce: number, payload: RelayerTransactionPayload): Promise<RelayerTransaction>;
@@ -256,6 +276,10 @@ export class Relayer implements IRelayer {
 
   public getRelayer(): Promise<RelayerGetResponse> {
     return this.relayer.getRelayer();
+  }
+
+  public getRelayerStatus(): Promise<RelayerStatus> {
+    return this.relayer.getRelayerStatus();
   }
 
   public sign(payload: SignMessagePayload): Promise<SignedMessagePayload> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,6 +1393,17 @@
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
+"@openzeppelin/defender-base-client@1.48.0", "@openzeppelin/defender-base-client@^1.49.0-rc.1":
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/defender-base-client/-/defender-base-client-1.48.0.tgz#9103b1b036db0451b52d7899a277bf24db4c4b06"
+  integrity sha512-HFO87s010hRrMjyh2xYOCEAkLe21BfIbho7n5/kikA6A1ZgXi7MsEiqnQv1zP4bxMJgxGZ5b3t4tt6fWrakbag==
+  dependencies:
+    amazon-cognito-identity-js "^6.0.1"
+    async-retry "^1.3.3"
+    axios "^1.4.0"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
+
 "@openzeppelin/defender-base-client@^1.45.0":
   version "1.46.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/defender-base-client/-/defender-base-client-1.46.0.tgz#aa5177f8fbad23fd03d78f3dbe06664bbe9333ff"
@@ -1415,14 +1426,14 @@
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
-"@openzeppelin/platform-deploy-client@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/platform-deploy-client/-/platform-deploy-client-0.7.0.tgz#e74eb6baa4b098ce8c1e15a6f1bfd9789edd6c08"
-  integrity sha512-3M8IaDuWUQ8n/Z8InI4pxGdc0G9zInZLSyH1zAvJyJ1JvR/IltXB5qG6pfWlqTFzuT/75W4pMdmu8zo71Dct6w==
+"@openzeppelin/defender-sentinel-client@1.48.0":
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/defender-sentinel-client/-/defender-sentinel-client-1.48.0.tgz#293e91d80314f4ba18ad811daea72c1abbc5860a"
+  integrity sha512-UoQTeC6Y3GK8uYWiyqMqnIOQHyI1SQ3MwOH0Z3OBbzR1xvCQZ+CcmBUnQQSxdfqcEXh+00MdUCRs+FbHZTESQQ==
   dependencies:
     "@ethersproject/abi" "^5.6.3"
-    "@openzeppelin/defender-base-client" "^1.45.0"
-    axios "^0.21.2"
+    "@openzeppelin/defender-base-client" "1.48.0"
+    axios "^1.4.0"
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
@@ -2685,7 +2696,6 @@ co@^4.6.0:
 
 "code-style@https://github.com/OpenZeppelin/code-style.git":
   version "0.1.0"
-  uid a6cd128e6f5225b15d76704708c5def97caa8176
   resolved "https://github.com/OpenZeppelin/code-style.git#a6cd128e6f5225b15d76704708c5def97caa8176"
 
 collect-v8-coverage@^1.0.0:
@@ -3130,15 +3140,15 @@ dotenv@^10.0.0, dotenv@~10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
+dotenv@^16.3.1, dotenv@~16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
-
-dotenv@~16.3.1:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
-  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
 duplexer@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
This PR will add support for relayer status endpoint.

This endpoint returns status info like consumed quotas, nonce and number of pending transactions.