### PR TITLE
add Edgeware mainnet and Beresheet testnet

### DIFF
--- a/packages/base/src/utils/network.ts
+++ b/packages/base/src/utils/network.ts
@@ -41,7 +41,9 @@ type PublicNetwork =
   | 'scroll'
   | 'scroll-sepolia'
   | 'meld'
-  | 'meld-kanazawa';
+  | 'meld-kanazawa'
+  | 'edgeware'
+  | 'beresheet';
 
 type CustomNetwork = 'x-dfk-avax-chain' | 'x-dfk-avax-chain-test';
 
@@ -91,6 +93,8 @@ export const Networks: Network[] = [
   'scroll-sepolia',
   'meld',
   'meld-kanazawa',
+  'edgeware',
+  'beresheet',
 ];
 export function isValidNetwork(text: string): text is Network {
   return (Networks as string[]).includes(text);
@@ -148,4 +152,6 @@ const chainIds: { [key in Network]: number } = {
   'scroll-sepolia': 534351,
   'meld': 0x13d92e8d,
   'meld-kanazawa': 0xd3b745e,
+  'edgeware': 2021,
+  'beresheet': 2022,
 };


### PR DESCRIPTION
Hi OpenZeppelin team!
Edgeware was founded by Commonwealth Labs back in 2017 as the first project within the substrate (Polkadot) ecosystem. It was launched as a governance experiment which evolved into a self-sustainable ecosystem/ chainDAO which is completely community owned and decentralized since the solochain genesis in Feb 2020. Edgeware is renowned for its fair distribution, dual smart contract environments, and community empowerment. We achieved one of the most equitable token distributions through our pioneering Lockdrop mechanism (90% of the initial supply airdropped to ETH holders), and our high-performance substrate solochain supports dual smart contract environments, EdgeEVM and EdgeWASM. As a true chainDAO, our community governs the on-chain treasury utilising the completely on-chain enforcing governance, which fuels the sustainability of our ecosystem.
Know more here: https://edgeware.io/